### PR TITLE
feat : 기수별 멤버 조회 (#6)

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/controller/user/UserController.java
+++ b/src/main/java/com/sammaru5/sammaru/controller/user/UserController.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController @RequiredArgsConstructor
 @Api(tags = {"사용자 API"})
@@ -60,5 +61,11 @@ public class UserController {
     @ApiOperation(value = "회원 정보 수정", notes = "회원 정보 수정하기", response = UserDTO.class)
     public ApiResult<?> userModify(Authentication authentication, @Valid @RequestBody UserRequest userRequest){
         return ApiResult.OK(userModifyService.modifyUser(authentication, userRequest));
+    }
+
+    @GetMapping("/api/users/gen/{generationNum}")
+    @ApiOperation(value = "기수에 대한 회원 정보 조회", notes = "generationNum으로 넘어온 기수에 대한 회원들에 대한 정보를 조회합니다.", response = UserDTO.class)
+    public ApiResult<List<UserDTO>> userListOfGeneration(@PathVariable Integer generationNum) {
+        return ApiResult.OK(userSearchService.findUsersByGeneration(generationNum));
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/domain/UserEntity.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/UserEntity.java
@@ -24,6 +24,7 @@ public class UserEntity {
     private String password;
     private String email;
     private Long point;
+    private Integer generation;
     private UserAuthority role;
 
     public void setRole(UserAuthority role) {

--- a/src/main/java/com/sammaru5/sammaru/dto/UserDTO.java
+++ b/src/main/java/com/sammaru5/sammaru/dto/UserDTO.java
@@ -15,6 +15,7 @@ public class UserDTO {
     private String email;
     private Long point;
     private UserAuthority role;
+    private Integer generation;
     private String nickname;
 
     public UserDTO(UserEntity userEntity){

--- a/src/main/java/com/sammaru5/sammaru/repository/UserRepository.java
+++ b/src/main/java/com/sammaru5/sammaru/repository/UserRepository.java
@@ -12,4 +12,5 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByStudentId(String studentId);
     boolean existsByStudentId(String studentId);
     List<UserEntity> findByRole(UserAuthority userAuthority);
+    List<UserEntity> findByGeneration(Integer generationNum);
 }

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserSearchService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserSearchService.java
@@ -24,4 +24,8 @@ public class UserSearchService {
     public List<UserDTO> findUsersByRole(UserAuthority role) {
         return userRepository.findByRole(role).stream().map(UserDTO::new).collect(Collectors.toList());
     }
+
+    public List<UserDTO> findUsersByGeneration(Integer generationNum) {
+        return userRepository.findByGeneration(generationNum).stream().map(UserDTO::new).collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #6 

## 📌 개요

기수별 멤버 조회 API 추가합니다.

## 👩‍💻 작업 사항

UserEntity와 UserDTO에 generation(Integer) 필드 추가하여 기수에 대한 정보를 가지게 하였습니다.
generation을 통해 멤버 조회가 가능하도록 했습니다.

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
