### PR TITLE
fix : ArticleEntity에서 ArticleDTO로의 변환 과정에서 일부 필드가 적용되지 않는 문제 수정(#32)

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/web/dto/ArticleDTO.java
+++ b/src/main/java/com/sammaru5/sammaru/web/dto/ArticleDTO.java
@@ -8,8 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.springframework.beans.BeanUtils.copyProperties;
-
 @Getter
 public class ArticleDTO {
     private Long id;
@@ -22,7 +20,9 @@ public class ArticleDTO {
     private List<FileDTO> files = new ArrayList<>();
 
     public ArticleDTO(ArticleEntity articleEntity) {
-        copyProperties(articleEntity, this);
+        this.id = articleEntity.getId();
+        this.title = articleEntity.getTitle();
+        this.content = articleEntity.getContent();
         this.createDt = articleEntity.getCreateTime();
         this.author = articleEntity.getUser().getUsername();
         this.viewCnt = articleEntity.getViewCnt();


### PR DESCRIPTION
## 👀 이슈

resolve #32 

## 📌 개요

ArticleEntity에서 ArticleDTO로의 변환 과정에서 일부 필드가 적용되지 않는 문제 수정

## 👩‍💻 작업 사항

copyProperties를 사용하지 않고 해당 필드에 직접 값 주입

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
