### PR TITLE
feat : 중요 게시판 삭제할때 Exception 발생

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/domain/IndelibleBoardName.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/IndelibleBoardName.java
@@ -1,0 +1,17 @@
+package com.sammaru5.sammaru.domain;
+
+public enum IndelibleBoardName {
+    공지사항,
+    사진첩,
+    족보;
+
+    public static boolean contain(String boardname) {
+        for (IndelibleBoardName indelibleBoardName : IndelibleBoardName.values()) {
+            if(indelibleBoardName.toString().equals(boardname)){
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
+++ b/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     BOARD_IS_EMPTY(HttpStatus.BAD_REQUEST, "해당 게시판에 게시글이 존재하지 않습니다!"),
     COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 댓글은 존재하지 않습니다!"),
     FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 파일은 존재하지 않습니다!"),
+    BOARD_NOT_REMOVE(HttpStatus.BAD_REQUEST, "해당 게시판은 삭제할 수 없습니다!"),
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED_USER_ACCESS(HttpStatus.UNAUTHORIZED, "권한이 없는 사용자의 접근입니다!"),

--- a/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
+++ b/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
@@ -14,7 +14,7 @@ public enum ErrorCode {
     BOARD_IS_EMPTY(HttpStatus.BAD_REQUEST, "해당 게시판에 게시글이 존재하지 않습니다!"),
     COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 댓글은 존재하지 않습니다!"),
     FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 파일은 존재하지 않습니다!"),
-    BOARD_NOT_REMOVE(HttpStatus.BAD_REQUEST, "해당 게시판은 삭제할 수 없습니다!"),
+    INDELIBLE_BOARD(HttpStatus.BAD_REQUEST, "해당 게시판은 삭제할 수 없습니다!"),
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED_USER_ACCESS(HttpStatus.UNAUTHORIZED, "권한이 없는 사용자의 접근입니다!"),

--- a/src/main/java/com/sammaru5/sammaru/service/board/BoardRemoveService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/board/BoardRemoveService.java
@@ -1,5 +1,7 @@
 package com.sammaru5.sammaru.service.board;
 
+import com.sammaru5.sammaru.exception.CustomException;
+import com.sammaru5.sammaru.exception.ErrorCode;
 import com.sammaru5.sammaru.repository.BoardRepository;
 import com.sammaru5.sammaru.service.article.ArticleRemoveService;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,12 @@ public class BoardRemoveService {
 
     @Transactional
     public boolean removeBoard(Long boardId)  {
+
+        String boardname = boardRepository.findById(boardId).get().getBoardName();
+        if(boardname.equals("족보") || boardname.equals("사진첩") || boardname.equals("공지사항")) {
+            new CustomException(ErrorCode.BOARD_NOT_REMOVE, boardId.toString());
+        }
+
         articleRemoveService.removeArticleByAdmin(boardId);
         boardRepository.deleteById(boardId);
         return true;

--- a/src/main/java/com/sammaru5/sammaru/service/board/BoardRemoveService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/board/BoardRemoveService.java
@@ -1,5 +1,6 @@
 package com.sammaru5.sammaru.service.board;
 
+import com.sammaru5.sammaru.domain.IndelibleBoardName;
 import com.sammaru5.sammaru.exception.CustomException;
 import com.sammaru5.sammaru.exception.ErrorCode;
 import com.sammaru5.sammaru.repository.BoardRepository;
@@ -20,8 +21,9 @@ public class BoardRemoveService {
     public boolean removeBoard(Long boardId)  {
 
         String boardname = boardRepository.findById(boardId).get().getBoardName();
-        if(boardname.equals("족보") || boardname.equals("사진첩") || boardname.equals("공지사항")) {
-            new CustomException(ErrorCode.BOARD_NOT_REMOVE, boardId.toString());
+
+        if(IndelibleBoardName.contain(boardname)) {
+            new CustomException(ErrorCode.INDELIBLE_BOARD, boardId.toString());
         }
 
         articleRemoveService.removeArticleByAdmin(boardId);


### PR DESCRIPTION
## 👀 이슈

resolve #25 

## 📌 개요

중요 게시판의 자료 삭제를 방지하기 위해 중요 게시판은 삭제가 되지 않도록 함

## 👩‍💻 작업 사항

중요 게시판 삭제시 BOARD_NOT_REMOVE 에러의 Exception을 발생시킴

## ✅ 참고 사항
