### PR TITLE
refactor: @CreationTimestamp 를 @CreatedDate로 변경하면서 JpaAuditing 추가

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/SammaruApplication.java
+++ b/src/main/java/com/sammaru5/sammaru/SammaruApplication.java
@@ -2,8 +2,10 @@ package com.sammaru5.sammaru;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SammaruApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/sammaru5/sammaru/domain/Article.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/Article.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.sql.Timestamp;
@@ -18,6 +20,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class Article {
 
     @Id @GeneratedValue
@@ -27,7 +30,7 @@ public class Article {
     private String title;
     private String content;
 
-    @CreationTimestamp
+    @CreatedDate
     private Timestamp createTime;
 
     private Integer viewCnt;

--- a/src/main/java/com/sammaru5/sammaru/domain/Article.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/Article.java
@@ -20,8 +20,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-public class Article {
+public class Article extends BaseTime {
 
     @Id @GeneratedValue
     @Column(name = "article_id")
@@ -29,9 +28,6 @@ public class Article {
 
     private String title;
     private String content;
-
-    @CreatedDate
-    private Timestamp createTime;
 
     private Integer viewCnt;
     private Integer likeCnt;

--- a/src/main/java/com/sammaru5/sammaru/domain/BaseTime.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/BaseTime.java
@@ -1,0 +1,22 @@
+package com.sammaru5.sammaru.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.sql.Timestamp;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTime {
+
+    @CreatedDate
+    private Timestamp createTime;
+
+    @LastModifiedDate
+    private Timestamp modifyTime;
+}

--- a/src/main/java/com/sammaru5/sammaru/domain/Board.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/Board.java
@@ -1,6 +1,7 @@
 package com.sammaru5.sammaru.domain;
 
 import com.sammaru5.sammaru.web.request.BoardRequest;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,6 +13,7 @@ import javax.persistence.Id;
 @Entity
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class Board {
 
     @Id @GeneratedValue

--- a/src/main/java/com/sammaru5/sammaru/domain/Comment.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/Comment.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor
-public class Comment {
+public class Comment extends BaseTime {
 
     @Id @GeneratedValue
     @Column(name = "comment_id")

--- a/src/test/java/com/sammaru5/sammaru/repository/ArticleRepositoryTest.java
+++ b/src/test/java/com/sammaru5/sammaru/repository/ArticleRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.sammaru5.sammaru.repository;
+
+import com.sammaru5.sammaru.domain.Article;
+import com.sammaru5.sammaru.domain.Board;
+import com.sammaru5.sammaru.domain.User;
+import com.sammaru5.sammaru.domain.UserAuthority;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+class ArticleRepositoryTest {
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Test
+    @DisplayName("@CreatedDate 동작 확인")
+    public void checkArticleCreateTime() {
+        // given
+        User user = User.builder()
+                .studentId("1111111")
+                .username("test")
+                .password("1234")
+                .email("test@gmail.com")
+                .point(0L)
+                .role(UserAuthority.ROLE_TEMP)
+                .build();
+        userRepository.save(user);
+
+        Board board = new Board(1L, "boardName", "description");
+        boardRepository.save(board);
+
+        // when
+        Article article = Article.builder()
+                .title("title")
+                .content("content")
+                .board(board)
+                .user(user)
+                .build();
+        articleRepository.save(article);
+
+        // then
+        List<Article> articleList = articleRepository.findAll();
+        Article generatedArticle = articleList.get(0);
+
+        System.out.println("generatedArticle.getCreateTime() = " + generatedArticle.getCreateTime());
+        assertThat(generatedArticle.getCreateTime()).isBefore(Instant.now());
+    }
+}


### PR DESCRIPTION
## 👀 이슈

resolve #27 

## 📌 개요

hibernate에 의존하지 않기 위해서 진행한 리팩토링

## 👩‍💻 작업 사항

- @CreationTimestamp 를 @CreatedDate로 변경하면서 JpaAuditing 추가
- 관련 테스트 코드 작성

<br>

- @CreatedDate, @LastModifiedDate를 field로 갖는 공통모듈인 BaseTime 추상화 클래스 생성 후 Article, Comment에 상속

## ✅ 참고 사항
