### PR TITLE
fix : 게시글 조회 시 첨부된 파일과 작성자를 한번에 볼 수 있도록 Query 수정

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/repository/ArticleRepository.java
+++ b/src/main/java/com/sammaru5/sammaru/repository/ArticleRepository.java
@@ -14,6 +14,14 @@ import java.util.Optional;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
+    @Query(value = "select a from Article a left join fetch a.files " +
+            "join fetch a.user where a.id = :id")
+    Optional<Article> findOneWithFilesAndUserById(@Param("id") Long id);
+
+    @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board",
+        countQuery = "select count(a) from Article a where a.board = :board")
+    List<Article> findArticlesWithFilesAndUserByBoard(@Param("board") Board board, Pageable pageable);
+
     @Query(value = "select a from Article a join fetch a.user where a.board = :board",
             countQuery = "select count(a) from Article a where a.board = :board")
     List<Article> findByBoard(@Param("board") Board board, Pageable pageable);

--- a/src/main/java/com/sammaru5/sammaru/web/dto/ArticleDTO.java
+++ b/src/main/java/com/sammaru5/sammaru/web/dto/ArticleDTO.java
@@ -24,14 +24,6 @@ public class ArticleDTO {
         return new ArticleDTO(article);
     }
 
-    public static ArticleDTO toDtoWithFile(Article article, List<File> files) {
-        return new ArticleDTO(article, files);
-    }
-
-    private ArticleDTO(Article article, List<File> files) {
-        this(article);
-        this.files = files.stream().map(FileDTO::new).collect(Collectors.toList());
-    }
     private ArticleDTO(Article article) {
         this.id = article.getId();
         this.title = article.getTitle();
@@ -40,5 +32,8 @@ public class ArticleDTO {
         this.author = article.getUser().getUsername();
         this.viewCnt = article.getViewCnt();
         this.likeCnt = article.getViewCnt();
+        if(!article.getFiles().isEmpty()) {
+            this.files = article.getFiles().stream().map(FileDTO::new).collect(Collectors.toList());
+        }
     }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #50 

## 📌 개요

게시글 조회 시 첨부된 파일이 조회되지 않는 현상이 있었습니다.

## 👩‍💻 작업 사항

게시글 조회 시 파일(`left join`)과 작성자(`join`)를 모두 join하여 한 번에 가져옵니다.
만약, 파일이 없다면 빈 `ArrayList`를 반환합니다.

## ✅ 참고 사항
파일을 `left join`한 이유는 게시글에 첨부된 파일이 존재하지 않을때도 게시글을 가져와야하기 때문에 사용하였습니다.
