### PR TITLE
feat: 임시 비밀번호를 메일로 받아볼 수 있는 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'

--- a/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
+++ b/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
 
     // 409 CONFLICT
     ALREADY_EXIST_USER(HttpStatus.CONFLICT, "해당 학번의 사용자가 이미 존재합니다!"),
+    ALREADY_EXIST_EMAIL(HttpStatus.CONFLICT, "해당 email 계정의 사용자가 이미 존재합니다!"),
     ALREADY_EXIST_BOARD(HttpStatus.CONFLICT, "해당 게시판이 이미 존재합니다!"),
     ;
 

--- a/src/main/java/com/sammaru5/sammaru/repository/UserRepository.java
+++ b/src/main/java/com/sammaru5/sammaru/repository/UserRepository.java
@@ -11,6 +11,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByStudentId(String studentId);
     boolean existsByStudentId(String studentId);
+    boolean existsByEmail(String email);
     List<User> findByRole(UserAuthority userAuthority);
     List<User> findByGeneration(Integer generationNum);
     Optional<User> findByEmail(String email);

--- a/src/main/java/com/sammaru5/sammaru/repository/UserRepository.java
+++ b/src/main/java/com/sammaru5/sammaru/repository/UserRepository.java
@@ -13,4 +13,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByStudentId(String studentId);
     List<User> findByRole(UserAuthority userAuthority);
     List<User> findByGeneration(Integer generationNum);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserModifyService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserModifyService.java
@@ -25,6 +25,9 @@ public class UserModifyService {
             user.setUsername(userRequest.getUsername());
         }
         if (userRequest.getEmail() != null) {
+            if (userRepository.existsByEmail(userRequest.getEmail())) {
+                throw new CustomException(ErrorCode.ALREADY_EXIST_EMAIL, userRequest.getEmail());
+            }
             user.setEmail(userRequest.getEmail());
         }
         if (userRequest.getPassword() != null) {

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserRegisterService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserRegisterService.java
@@ -23,6 +23,10 @@ public class UserRegisterService {
             throw new CustomException(ErrorCode.ALREADY_EXIST_USER, signUpRequest.getStudentId());
         }
 
+        if (userRepository.existsByEmail(signUpRequest.getEmail())) {
+            throw new CustomException(ErrorCode.ALREADY_EXIST_EMAIL, signUpRequest.getEmail());
+        }
+
         User user = signUpRequest.toEntityWithEncryptingPassword(passwordEncoder);
         return new UserDTO(userRepository.save(user));
     }

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserTempPasswordService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserTempPasswordService.java
@@ -4,7 +4,6 @@ import com.sammaru5.sammaru.domain.User;
 import com.sammaru5.sammaru.exception.CustomException;
 import com.sammaru5.sammaru.exception.ErrorCode;
 import com.sammaru5.sammaru.repository.UserRepository;
-import com.sammaru5.sammaru.web.dto.UserDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -24,16 +23,15 @@ public class UserTempPasswordService {
     private final PasswordEncoder passwordEncoder;
     private final JavaMailSender javaMailSender;
 
-    public UserDTO sendTempPassword(String userEmail) {
+    public Long sendTempPassword(String userEmail) {
         User user = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, userEmail));
-
 
         String tempPassword = getRandomPassword((int) (Math.random() * 13) + 8);
         user.setPassword(passwordEncoder.encode(tempPassword));
 
         sendMail(userEmail, tempPassword);
-        return new UserDTO(user);
+        return user.getId();
     }
 
     public String getRandomPassword(int size) {

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserTempPasswordService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserTempPasswordService.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
 import java.util.Date;
-import java.util.Optional;
 
 @Transactional
 @Service
@@ -25,9 +24,9 @@ public class UserTempPasswordService {
     private final JavaMailSender javaMailSender;
 
     public UserDTO sendTempPassword(String userEmail) {
-        Optional<User> findUser = userRepository.findByEmail(userEmail);
-        if (findUser.isEmpty()) throw new CustomException(ErrorCode.USER_NOT_FOUND, userEmail);
-        User user = findUser.get();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, userEmail));
+
 
         String tempPassword = getRandomPassword((int) (Math.random() * 13) + 8);
         user.setPassword(passwordEncoder.encode(tempPassword));

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserTempPasswordService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserTempPasswordService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
 import java.util.Date;
+import java.util.regex.Pattern;
 
 @Transactional
 @Service
@@ -36,21 +37,28 @@ public class UserTempPasswordService {
     }
 
     public String getRandomPassword(int size) {
+        final String regex = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}";
+
         char[] charSet = new char[]{
                 '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
                 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
                 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-                '!', '@', '#', '$', '%', '^', '&'
+                '!', '@', '#', '$', '%', '&'
         };
         StringBuilder sb = new StringBuilder();
         SecureRandom sr = new SecureRandom();
         sr.setSeed(new Date().getTime());
 
-        for (int i = 0; i < size; i++) {
-            int idx = sr.nextInt(charSet.length);
-            sb.append(charSet[idx]);
+        while (true) {
+            for (int i = 0; i < size; i++) {
+                int idx = sr.nextInt(charSet.length);
+                sb.append(charSet[idx]);
+            }
+
+            if (Pattern.matches(regex, sb.toString())) {
+                return sb.toString();
+            }
         }
-        return sb.toString();
     }
 
     public void sendMail(String userEmail, String tempPassword) {

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserTempPasswordService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserTempPasswordService.java
@@ -1,0 +1,52 @@
+package com.sammaru5.sammaru.service.user;
+
+import com.sammaru5.sammaru.domain.User;
+import com.sammaru5.sammaru.exception.CustomException;
+import com.sammaru5.sammaru.exception.ErrorCode;
+import com.sammaru5.sammaru.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.util.Date;
+import java.util.Optional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class UserTempPasswordService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public String sendTempPassword(String email) {
+        Optional<User> findUser = userRepository.findByEmail(email);
+        if (findUser.isEmpty()) throw new CustomException(ErrorCode.USER_NOT_FOUND, email);
+        User user = findUser.get();
+
+        String tempPassword = getRandomPassword((int) (Math.random() * 13) + 8);
+        user.setPassword(passwordEncoder.encode(tempPassword));
+
+        // TODO : 메일 발송
+        return tempPassword;
+    }
+
+    public String getRandomPassword(int size) {
+        char[] charSet = new char[]{
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+                '!', '@', '#', '$', '%', '^', '&'
+        };
+        StringBuilder sb = new StringBuilder();
+        SecureRandom sr = new SecureRandom();
+        sr.setSeed(new Date().getTime());
+
+        for (int i = 0; i < size; i++) {
+            int idx = sr.nextInt(charSet.length);
+            sb.append(charSet[idx]);
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/sammaru5/sammaru/web/controller/auth/AuthController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/auth/AuthController.java
@@ -46,8 +46,8 @@ public class AuthController {
     }
 
     @PostMapping("/auth/tempPassword")
-    @ApiOperation(value = "임시 비밀번호 생성", notes = "계정에 등록되어 있는 메일로 임시 비밀번호 발송")
-    public ApiResult<?> sendTempPassword(@RequestParam String userEmail) {
+    @ApiOperation(value = "임시 비밀번호 생성", notes = "계정에 등록되어 있는 메일로 임시 비밀번호 발송", response = UserDTO.class)
+    public ApiResult<UserDTO> sendTempPassword(@RequestParam String userEmail) {
         return ApiResult.OK(userTempPasswordService.sendTempPassword(userEmail));
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/web/controller/auth/AuthController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/auth/AuthController.java
@@ -1,18 +1,21 @@
 package com.sammaru5.sammaru.web.controller.auth;
 
+import com.sammaru5.sammaru.service.user.UserLoginService;
+import com.sammaru5.sammaru.service.user.UserRegisterService;
+import com.sammaru5.sammaru.service.user.UserReissueService;
 import com.sammaru5.sammaru.service.user.UserTempPasswordService;
 import com.sammaru5.sammaru.web.apiresult.ApiResult;
 import com.sammaru5.sammaru.web.dto.JwtDTO;
 import com.sammaru5.sammaru.web.dto.UserDTO;
 import com.sammaru5.sammaru.web.request.SignInRequest;
 import com.sammaru5.sammaru.web.request.SignUpRequest;
-import com.sammaru5.sammaru.service.user.UserLoginService;
-import com.sammaru5.sammaru.service.user.UserRegisterService;
-import com.sammaru5.sammaru.service.user.UserReissueService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -29,7 +32,7 @@ public class AuthController {
 
     @PostMapping("/auth/signup")
     @ApiOperation(value = "회원가입", notes = "사용자 회원가입", response = UserDTO.class)
-    public ApiResult<?> userSignUp(@Valid @RequestBody SignUpRequest signUpRequest){
+    public ApiResult<?> userSignUp(@Valid @RequestBody SignUpRequest signUpRequest) {
         return ApiResult.OK(userRegisterService.signUpUser(signUpRequest));
     }
 
@@ -46,8 +49,8 @@ public class AuthController {
     }
 
     @PostMapping("/auth/tempPassword")
-    @ApiOperation(value = "임시 비밀번호 생성", notes = "계정에 등록되어 있는 메일로 임시 비밀번호 발송", response = UserDTO.class)
-    public ApiResult<UserDTO> sendTempPassword(@RequestParam String userEmail) {
+    @ApiOperation(value = "임시 비밀번호 생성", notes = "계정에 등록되어 있는 메일로 임시 비밀번호 발송, 성공시 해당 유저의 id 반환", response = Long.class)
+    public ApiResult<Long> sendTempPassword(@RequestParam String userEmail) {
         return ApiResult.OK(userTempPasswordService.sendTempPassword(userEmail));
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/web/controller/auth/AuthController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/auth/AuthController.java
@@ -1,5 +1,6 @@
 package com.sammaru5.sammaru.web.controller.auth;
 
+import com.sammaru5.sammaru.service.user.UserTempPasswordService;
 import com.sammaru5.sammaru.web.apiresult.ApiResult;
 import com.sammaru5.sammaru.web.dto.JwtDTO;
 import com.sammaru5.sammaru.web.dto.UserDTO;
@@ -16,13 +17,15 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
-@RestController @RequiredArgsConstructor
+@RestController
+@RequiredArgsConstructor
 @Api(tags = {"회원 인증 API"})
 public class AuthController {
 
     private final UserRegisterService userRegisterService;
     private final UserLoginService userLoginService;
     private final UserReissueService userReissueService;
+    private final UserTempPasswordService userTempPasswordService;
 
     @PostMapping("/auth/signup")
     @ApiOperation(value = "회원가입", notes = "사용자 회원가입", response = UserDTO.class)
@@ -40,5 +43,11 @@ public class AuthController {
     @ApiOperation(value = "엑세스 토큰 재발급", notes = "만료된 엑세스 토큰과, 리프레쉬 토큰을 이용해 토큰 재 발급", response = JwtDTO.class)
     public ApiResult<?> userReissue(HttpServletRequest request) {
         return ApiResult.OK(userReissueService.reissueUser(request));
+    }
+
+    @PostMapping("/auth/tempPassword")
+    @ApiOperation(value = "임시 비밀번호 생성", notes = "계정에 등록되어 있는 메일로 임시 비밀번호 발송")
+    public ApiResult<?> sendTempPassword(@RequestParam String userEmail) {
+        return ApiResult.OK(userTempPasswordService.sendTempPassword(userEmail));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,18 @@ spring:
         show_sql: true
         format_sql: true
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: cbnusammaru@gmail.com
+    password: selrmkiajopthqkt
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 app:
   jwtRefreshTokenValidTime: 1800000
   jwtTokenValidTime: 900000


### PR DESCRIPTION
## 👀 이슈

resolve #44 

## 📌 개요

비밀번호를 잊어버렸을시, 메일을 입력하면 해당 계정에 대한 임시 비밀번호를 메일로 보내주는 기능

## 👩‍💻 작업 사항

- `SecureRandom`을 활용한 임시 비밀번호 생성
- `JavaMailSender`를 통한 메일 전송 기능 구현
- 동아리 gmail 계정 생성

<br>

- 회원가입, 회원 정보 수정 시에 이메일 중복 여부 체크 기능 추가

## ✅ 참고 사항
