### PR TITLE
feat: 게시글 검색 기능 추가

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/domain/SearchSubject.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/SearchSubject.java
@@ -1,0 +1,9 @@
+package com.sammaru5.sammaru.domain;
+
+public enum SearchSubject {
+    WRITER_STUDENT_ID,
+    WRITER_NAME,
+    ARTICLE_TITLE,
+    ARTICLE_CONTENT,
+    ARTICLE_TITLE_AND_CONTENT
+}

--- a/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
+++ b/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 파일은 존재하지 않습니다!"),
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 회원은 존재하지 않습니다!"),
     INDELIBLE_BOARD(HttpStatus.BAD_REQUEST, "해당 게시판은 삭제할 수 없습니다!"),
+    WRONG_SEARCH_SUBJECT(HttpStatus.BAD_REQUEST, "올바르지 않은 검색 주제입니다!"),
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED_USER_ACCESS(HttpStatus.UNAUTHORIZED, "권한이 없는 사용자의 접근입니다!"),

--- a/src/main/java/com/sammaru5/sammaru/repository/ArticleRepository.java
+++ b/src/main/java/com/sammaru5/sammaru/repository/ArticleRepository.java
@@ -19,7 +19,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     Optional<Article> findOneWithFilesAndUserById(@Param("id") Long id);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board",
-        countQuery = "select count(a) from Article a where a.board = :board")
+            countQuery = "select count(a) from Article a where a.board = :board")
     List<Article> findArticlesWithFilesAndUserByBoard(@Param("board") Board board, Pageable pageable);
 
     @Query(value = "select a from Article a join fetch a.user where a.board = :board",
@@ -37,4 +37,49 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     @Modifying
     @Query(value = "delete from Article a where a.id in :ids")
     void deleteAllByIdInQuery(@Param("ids") List<Long> ids);
+
+    // -------------------------- 특정 게시판 게시글 검색 --------------------------------------
+
+    @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board and a.user.studentId = :studentId",
+            countQuery = "select count(a) from Article a where a.board = :board and a.user.studentId = :studentId")
+    List<Article> findArticlesWithFilesAndUserByBoardAndWriterStudentId(@Param("board") Board board, Pageable pageable, @Param("studentId") String studentId);
+
+    @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board and a.user.username = :username",
+            countQuery = "select count(a) from Article a where a.board = :board and a.user.username = :username")
+    List<Article> findArticlesWithFilesAndUserByBoardAndWriterUsername(@Param("board") Board board, Pageable pageable, @Param("username") String username);
+
+    @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board and a.title like %:keyword%",
+            countQuery = "select count(a) from Article a where a.board = :board and a.title like %:keyword%")
+    List<Article> findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitle(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
+
+    @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board and a.content like %:keyword%",
+            countQuery = "select count(a) from Article a where a.board = :board and a.content like %:keyword%")
+    List<Article> findArticlesWithFilesAndUserByBoardAndKeywordForArticleContent(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
+
+    @Query(value = "select a from Article a left join fetch a.files join fetch a.user where (a.board = :board) and (a.title like %:keyword% or a.content like %:keyword%)",
+            countQuery = "select count(a) from Article a where (a.board = :board) and (a.title like %:keyword% or a.content like %:keyword%)")
+    List<Article> findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitleAndArticleContent(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
+
+    // -------------------- 전체 게시판 게시글 검색 ------------------------
+
+    @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.user.studentId = :studentId",
+            countQuery = "select count(a) from Article a where a.user.studentId = :studentId")
+    List<Article> findArticlesWithFilesAndUserByWriterStudentId(Pageable pageable, @Param("studentId") String studentId);
+
+    @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.user.username = :username",
+            countQuery = "select count(a) from Article a where a.user.username = :username")
+    List<Article> findArticlesWithFilesAndUserByWriterUsername(Pageable pageable, @Param("username") String username);
+
+    @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.title like %:keyword%",
+            countQuery = "select count(a) from Article a where a.title like %:keyword%")
+    List<Article> findArticlesWithFilesAndUserByKeywordForArticleTitle(Pageable pageable, @Param("keyword") String keyword);
+
+    @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.content like %:keyword%",
+            countQuery = "select count(a) from Article a where a.content like %:keyword%")
+    List<Article> findArticlesWithFilesAndUserByKeywordForArticleContent(Pageable pageable, @Param("keyword") String keyword);
+
+    @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.title like %:keyword% or a.content like %:keyword%",
+            countQuery = "select count(a) from Article a where a.title like %:keyword% or a.content like %:keyword%")
+    List<Article> findArticlesWithFilesAndUserByKeywordForArticleTitleAndArticleContent(Pageable pageable, @Param("keyword") String keyword);
+
 }

--- a/src/main/java/com/sammaru5/sammaru/repository/ArticleRepository.java
+++ b/src/main/java/com/sammaru5/sammaru/repository/ArticleRepository.java
@@ -42,44 +42,44 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board and a.user.studentId = :studentId",
             countQuery = "select count(a) from Article a where a.board = :board and a.user.studentId = :studentId")
-    List<Article> findArticlesWithFilesAndUserByBoardAndWriterStudentId(@Param("board") Board board, Pageable pageable, @Param("studentId") String studentId);
+    List<Article> searchArticlesByBoardAndStudentId(@Param("board") Board board, Pageable pageable, @Param("studentId") String studentId);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board and a.user.username = :username",
             countQuery = "select count(a) from Article a where a.board = :board and a.user.username = :username")
-    List<Article> findArticlesWithFilesAndUserByBoardAndWriterUsername(@Param("board") Board board, Pageable pageable, @Param("username") String username);
+    List<Article> searchArticlesByBoardAndUsername(@Param("board") Board board, Pageable pageable, @Param("username") String username);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board and a.title like %:keyword%",
             countQuery = "select count(a) from Article a where a.board = :board and a.title like %:keyword%")
-    List<Article> findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitle(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
+    List<Article> searchArticlesByBoardAndTitle(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board and a.content like %:keyword%",
             countQuery = "select count(a) from Article a where a.board = :board and a.content like %:keyword%")
-    List<Article> findArticlesWithFilesAndUserByBoardAndKeywordForArticleContent(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
+    List<Article> searchArticlesByBoardAndContent(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where (a.board = :board) and (a.title like %:keyword% or a.content like %:keyword%)",
             countQuery = "select count(a) from Article a where (a.board = :board) and (a.title like %:keyword% or a.content like %:keyword%)")
-    List<Article> findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitleAndArticleContent(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
+    List<Article> searchArticlesByBoardAndTitleAndContent(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
 
     // -------------------- 전체 게시판 게시글 검색 ------------------------
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.user.studentId = :studentId",
             countQuery = "select count(a) from Article a where a.user.studentId = :studentId")
-    List<Article> findArticlesWithFilesAndUserByWriterStudentId(Pageable pageable, @Param("studentId") String studentId);
+    List<Article> searchArticlesByStudentId(Pageable pageable, @Param("studentId") String studentId);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.user.username = :username",
             countQuery = "select count(a) from Article a where a.user.username = :username")
-    List<Article> findArticlesWithFilesAndUserByWriterUsername(Pageable pageable, @Param("username") String username);
+    List<Article> searchArticlesByUsername(Pageable pageable, @Param("username") String username);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.title like %:keyword%",
             countQuery = "select count(a) from Article a where a.title like %:keyword%")
-    List<Article> findArticlesWithFilesAndUserByKeywordForArticleTitle(Pageable pageable, @Param("keyword") String keyword);
+    List<Article> searchArticlesByTitle(Pageable pageable, @Param("keyword") String keyword);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.content like %:keyword%",
             countQuery = "select count(a) from Article a where a.content like %:keyword%")
-    List<Article> findArticlesWithFilesAndUserByKeywordForArticleContent(Pageable pageable, @Param("keyword") String keyword);
+    List<Article> searchArticlesByContent(Pageable pageable, @Param("keyword") String keyword);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.title like %:keyword% or a.content like %:keyword%",
             countQuery = "select count(a) from Article a where a.title like %:keyword% or a.content like %:keyword%")
-    List<Article> findArticlesWithFilesAndUserByKeywordForArticleTitleAndArticleContent(Pageable pageable, @Param("keyword") String keyword);
+    List<Article> searchArticlesByTitleAndContent(Pageable pageable, @Param("keyword") String keyword);
 
 }

--- a/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
@@ -78,19 +78,19 @@ public class ArticleSearchService {
         List<Article> articles;
         switch (searchSubject) {
             case WRITER_STUDENT_ID:
-                articles = articleRepository.findArticlesWithFilesAndUserByBoardAndWriterStudentId(findBoard, pageable, keyword);
+                articles = articleRepository.searchArticlesByBoardAndStudentId(findBoard, pageable, keyword);
                 break;
             case WRITER_NAME:
-                articles = articleRepository.findArticlesWithFilesAndUserByBoardAndWriterUsername(findBoard, pageable, keyword);
+                articles = articleRepository.searchArticlesByBoardAndUsername(findBoard, pageable, keyword);
                 break;
             case ARTICLE_TITLE:
-                articles = articleRepository.findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitle(findBoard, pageable, keyword);
+                articles = articleRepository.searchArticlesByBoardAndTitle(findBoard, pageable, keyword);
                 break;
             case ARTICLE_CONTENT:
-                articles = articleRepository.findArticlesWithFilesAndUserByBoardAndKeywordForArticleContent(findBoard, pageable, keyword);
+                articles = articleRepository.searchArticlesByBoardAndContent(findBoard, pageable, keyword);
                 break;
             case ARTICLE_TITLE_AND_CONTENT:
-                articles = articleRepository.findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitleAndArticleContent(findBoard, pageable, keyword);
+                articles = articleRepository.searchArticlesByBoardAndTitleAndContent(findBoard, pageable, keyword);
                 break;
             default:
                 throw new CustomException(ErrorCode.WRONG_SEARCH_SUBJECT, searchSubject.name());
@@ -104,19 +104,19 @@ public class ArticleSearchService {
         List<Article> articles;
         switch (searchSubject) {
             case WRITER_STUDENT_ID:
-                articles = articleRepository.findArticlesWithFilesAndUserByWriterStudentId(pageable, keyword);
+                articles = articleRepository.searchArticlesByStudentId(pageable, keyword);
                 break;
             case WRITER_NAME:
-                articles = articleRepository.findArticlesWithFilesAndUserByWriterUsername(pageable, keyword);
+                articles = articleRepository.searchArticlesByUsername(pageable, keyword);
                 break;
             case ARTICLE_TITLE:
-                articles = articleRepository.findArticlesWithFilesAndUserByKeywordForArticleTitle(pageable, keyword);
+                articles = articleRepository.searchArticlesByTitle(pageable, keyword);
                 break;
             case ARTICLE_CONTENT:
-                articles = articleRepository.findArticlesWithFilesAndUserByKeywordForArticleContent(pageable, keyword);
+                articles = articleRepository.searchArticlesByContent(pageable, keyword);
                 break;
             case ARTICLE_TITLE_AND_CONTENT:
-                articles = articleRepository.findArticlesWithFilesAndUserByKeywordForArticleTitleAndArticleContent(pageable, keyword);
+                articles = articleRepository.searchArticlesByTitleAndContent(pageable, keyword);
                 break;
             default:
                 throw new CustomException(ErrorCode.WRONG_SEARCH_SUBJECT, searchSubject.name());

--- a/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
@@ -2,7 +2,7 @@ package com.sammaru5.sammaru.service.article;
 
 import com.sammaru5.sammaru.domain.Article;
 import com.sammaru5.sammaru.domain.Board;
-import com.sammaru5.sammaru.domain.File;
+import com.sammaru5.sammaru.domain.SearchSubject;
 import com.sammaru5.sammaru.exception.CustomException;
 import com.sammaru5.sammaru.exception.ErrorCode;
 import com.sammaru5.sammaru.repository.ArticleRepository;
@@ -69,5 +69,58 @@ public class ArticleSearchService {
         }
 
         return findArticles.stream().map(ArticleDTO::toDto).collect(Collectors.toList());
+    }
+
+    public List<ArticleDTO> findArticlesByBoardIdAndKeywordAndPaging(Long boardId, Integer pageNum, SearchSubject searchSubject, String keyword) {
+        Board findBoard = boardStatusService.findBoard(boardId);
+        Pageable pageable = PageRequest.of(pageNum, 15, Sort.by("createTime").descending());
+
+        List<Article> articles;
+        switch (searchSubject) {
+            case WRITER_STUDENT_ID:
+                articles = articleRepository.findArticlesWithFilesAndUserByBoardAndWriterStudentId(findBoard, pageable, keyword);
+                break;
+            case WRITER_NAME:
+                articles = articleRepository.findArticlesWithFilesAndUserByBoardAndWriterUsername(findBoard, pageable, keyword);
+                break;
+            case ARTICLE_TITLE:
+                articles = articleRepository.findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitle(findBoard, pageable, keyword);
+                break;
+            case ARTICLE_CONTENT:
+                articles = articleRepository.findArticlesWithFilesAndUserByBoardAndKeywordForArticleContent(findBoard, pageable, keyword);
+                break;
+            case ARTICLE_TITLE_AND_CONTENT:
+                articles = articleRepository.findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitleAndArticleContent(findBoard, pageable, keyword);
+                break;
+            default:
+                throw new CustomException(ErrorCode.WRONG_SEARCH_SUBJECT, searchSubject.name());
+        }
+        return articles.stream().map(ArticleDTO::toDto).collect(Collectors.toList());
+    }
+
+    public List<ArticleDTO> findArticlesByKeywordAndPaging(Integer pageNum, SearchSubject searchSubject, String keyword) {
+        Pageable pageable = PageRequest.of(pageNum, 15, Sort.by("createTime").descending());
+
+        List<Article> articles;
+        switch (searchSubject) {
+            case WRITER_STUDENT_ID:
+                articles = articleRepository.findArticlesWithFilesAndUserByWriterStudentId(pageable, keyword);
+                break;
+            case WRITER_NAME:
+                articles = articleRepository.findArticlesWithFilesAndUserByWriterUsername(pageable, keyword);
+                break;
+            case ARTICLE_TITLE:
+                articles = articleRepository.findArticlesWithFilesAndUserByKeywordForArticleTitle(pageable, keyword);
+                break;
+            case ARTICLE_CONTENT:
+                articles = articleRepository.findArticlesWithFilesAndUserByKeywordForArticleContent(pageable, keyword);
+                break;
+            case ARTICLE_TITLE_AND_CONTENT:
+                articles = articleRepository.findArticlesWithFilesAndUserByKeywordForArticleTitleAndArticleContent(pageable, keyword);
+                break;
+            default:
+                throw new CustomException(ErrorCode.WRONG_SEARCH_SUBJECT, searchSubject.name());
+        }
+        return articles.stream().map(ArticleDTO::toDto).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/web/controller/board/BoardController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/board/BoardController.java
@@ -1,6 +1,8 @@
 package com.sammaru5.sammaru.web.controller.board;
 
+import com.sammaru5.sammaru.domain.SearchSubject;
 import com.sammaru5.sammaru.util.OverAdminRole;
+import com.sammaru5.sammaru.util.OverMemberRole;
 import com.sammaru5.sammaru.web.apiresult.ApiResult;
 import com.sammaru5.sammaru.web.dto.ArticleDTO;
 import com.sammaru5.sammaru.web.dto.BoardDTO;
@@ -18,7 +20,8 @@ import javax.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@RestController @RequiredArgsConstructor
+@RestController
+@RequiredArgsConstructor
 @Api(tags = {"게시판 API"})
 public class BoardController {
 
@@ -42,14 +45,26 @@ public class BoardController {
     }
 
     @GetMapping("/no-permit/api/boards")
-    @ApiOperation(value = "게시판 목록", notes = "게시판 목록을 조회", responseContainer = "List",response = BoardDTO.class)
+    @ApiOperation(value = "게시판 목록", notes = "게시판 목록을 조회", responseContainer = "List", response = BoardDTO.class)
     public ApiResult<List<BoardDTO>> boardList() {
         return ApiResult.OK(boardStatusService.findBoards().stream().map(BoardDTO::new).collect(Collectors.toList()));
     }
 
     @GetMapping("/no-permit/api/boards/{boardId}/pages/{pageNum}")
-    @ApiOperation(value = "게시판 세부 정보 조회", notes = "해당 게시판의 게시글들을 조회 ex.자유게시판", responseContainer = "List",response = ArticleDTO.class)
+    @ApiOperation(value = "게시판 세부 정보 조회", notes = "해당 게시판의 게시글들을 조회 ex.자유게시판", responseContainer = "List", response = ArticleDTO.class)
     public ApiResult<List<ArticleDTO>> boardDetails(@PathVariable Long boardId, @PathVariable Integer pageNum) {
         return ApiResult.OK(articleSearchService.findArticlesByBoardIdAndPaging(boardId, pageNum - 1));
+    }
+
+    @GetMapping("/no-permit/api/boards/{boardId}/searchResult/pages/{pageNum}")
+    @ApiOperation(value = "특정 게시판 검색", notes = "해당 게시판을 대상으로 게시글들을 검색 ex.자유게시판", responseContainer = "List", response = ArticleDTO.class)
+    public ApiResult<List<ArticleDTO>> boardSearch(@PathVariable Long boardId, @PathVariable Integer pageNum, @RequestParam SearchSubject searchSubject, @RequestParam String keyword) {
+        return ApiResult.OK(articleSearchService.findArticlesByBoardIdAndKeywordAndPaging(boardId, pageNum - 1, searchSubject, keyword));
+    }
+
+    @GetMapping("/no-permit/api/boards/searchResult/pages/{pageNum}")
+    @ApiOperation(value = "모든 게시판 검색", notes = "모든 게시판을 대상으로 게시글들을 검색", responseContainer = "List", response = ArticleDTO.class)
+    public ApiResult<List<ArticleDTO>> search(@PathVariable Integer pageNum, @RequestParam SearchSubject searchSubject, @RequestParam String keyword) {
+        return ApiResult.OK(articleSearchService.findArticlesByKeywordAndPaging(pageNum - 1, searchSubject, keyword));
     }
 }

--- a/src/test/java/com/sammaru5/sammaru/repository/ArticleRepositoryTest.java
+++ b/src/test/java/com/sammaru5/sammaru/repository/ArticleRepositoryTest.java
@@ -47,12 +47,7 @@ class ArticleRepositoryTest {
         boardRepository.save(board);
 
         // when
-        Article article = Article.builder()
-                .title("title")
-                .content("content")
-                .board(board)
-                .user(user)
-                .build();
+        Article article = new Article(null, "title", "content", 0, 0, board, user, null);
         articleRepository.save(article);
 
         // then

--- a/src/test/java/com/sammaru5/sammaru/repository/ArticlesSearchTest.java
+++ b/src/test/java/com/sammaru5/sammaru/repository/ArticlesSearchTest.java
@@ -73,7 +73,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByBoardAndWriterStudentId() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByBoardAndWriterStudentId(boards[0], pageable, users[0].getStudentId());
+        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndStudentId(boards[0], pageable, users[0].getStudentId());
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -85,7 +85,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByBoardAndWriterUsername() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByBoardAndWriterUsername(boards[1], pageable, users[1].getUsername());
+        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndUsername(boards[1], pageable, users[1].getUsername());
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -97,7 +97,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitle() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitle(boards[2], pageable, "키워드");
+        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndTitle(boards[2], pageable, "키워드");
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -109,7 +109,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByBoardAndKeywordForArticleContent() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByBoardAndKeywordForArticleContent(boards[0], pageable, "키워드");
+        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndContent(boards[0], pageable, "키워드");
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -121,7 +121,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitleAndArticleContent() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitleAndArticleContent(boards[1], pageable, "키워드");
+        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndTitleAndContent(boards[1], pageable, "키워드");
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -135,7 +135,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByWriterStudentId() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByWriterStudentId(pageable, users[0].getStudentId());
+        List<Article> searchedArticles = articleRepository.searchArticlesByStudentId(pageable, users[0].getStudentId());
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -152,7 +152,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByWriterUsername() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByWriterUsername(pageable, users[1].getUsername());
+        List<Article> searchedArticles = articleRepository.searchArticlesByUsername(pageable, users[1].getUsername());
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -169,7 +169,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByKeywordForArticleTitle() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByKeywordForArticleTitle(pageable, "키워드");
+        List<Article> searchedArticles = articleRepository.searchArticlesByTitle(pageable, "키워드");
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -186,7 +186,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByKeywordForArticleContent() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByKeywordForArticleContent(pageable, "키워드");
+        List<Article> searchedArticles = articleRepository.searchArticlesByContent(pageable, "키워드");
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -203,7 +203,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByKeywordForArticleTitleAndArticleContent() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByKeywordForArticleTitleAndArticleContent(pageable, "키워드");
+        List<Article> searchedArticles = articleRepository.searchArticlesByTitleAndContent(pageable, "키워드");
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());

--- a/src/test/java/com/sammaru5/sammaru/repository/ArticlesSearchTest.java
+++ b/src/test/java/com/sammaru5/sammaru/repository/ArticlesSearchTest.java
@@ -1,0 +1,218 @@
+package com.sammaru5.sammaru.repository;
+
+import com.sammaru5.sammaru.domain.Article;
+import com.sammaru5.sammaru.domain.Board;
+import com.sammaru5.sammaru.domain.User;
+import com.sammaru5.sammaru.domain.UserAuthority;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+class ArticlesSearchTest {
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    User[] users;
+    Board[] boards;
+    Article[][] articles;
+
+    @BeforeEach
+    public void setUp() {
+        //given
+        users = new User[2];
+        for (int i = 0; i < users.length; i++) {
+            users[i] = User.builder().studentId("1111111" + i).username("test" + i).password("1234").email("test" + i + "@gmail.com").point(0L).role(UserAuthority.ROLE_MEMBER).build();
+            users[i] = userRepository.save(users[i]);
+        }
+
+        boards = new Board[3];
+        String[] boardNames = new String[]{"자유게시판", "사진첩", "공지사항"};
+        for (int i = 0; i < boards.length; i++) {
+            boards[i] = new Board(null, boardNames[i], "description" + i);
+            boards[i] = boardRepository.save(boards[i]);
+        }
+
+        articles = new Article[boards.length][4];
+        String[] titles = new String[]{"title", "어쩌구 키워드 어쩌구", "title3", "키워드로 시작"};
+        String[] contents = new String[]{"어쩌구 키워드", "키워드", "아무거나", "아무거나"};
+        for (int i = 0; i < boards.length; i++) {
+            for (int j = 0; j < 4; j++) {
+                articles[i][j] = new Article(null, titles[j] + i * j, i * j + contents[j], 0, 0, boards[i], users[j % 2], null);
+                articles[i][j] = articleRepository.save(articles[i][j]);
+            }
+        }
+    }
+
+    // ----------------- 특정 게시판 게시글 검색 테스트 ------------------------
+
+    @Test
+    @DisplayName("특정 게시판에서 작성자 학번으로 게시글 검색")
+    void findArticlesWithFilesAndUserByBoardAndWriterStudentId() {
+        //when
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
+        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByBoardAndWriterStudentId(boards[0], pageable, users[0].getStudentId());
+
+        //then
+        List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
+        assertThat(searchedArticlesIds).hasSameElementsAs(Arrays.asList(articles[0][0].getId(), articles[0][2].getId()));
+    }
+
+    @Test
+    @DisplayName("특정 게시판에서 작성자 이름으로 게시글 검색")
+    void findArticlesWithFilesAndUserByBoardAndWriterUsername() {
+        //when
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
+        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByBoardAndWriterUsername(boards[1], pageable, users[1].getUsername());
+
+        //then
+        List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
+        assertThat(searchedArticlesIds).hasSameElementsAs(Arrays.asList(articles[1][1].getId(), articles[1][3].getId()));
+    }
+
+    @Test
+    @DisplayName("특정 게시판에서 게시글 제목으로 게시글 검색")
+    void findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitle() {
+        //when
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
+        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitle(boards[2], pageable, "키워드");
+
+        //then
+        List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
+        assertThat(searchedArticlesIds).hasSameElementsAs(Arrays.asList(articles[2][1].getId(), articles[2][3].getId()));
+    }
+
+    @Test
+    @DisplayName("특정 게시판에서 게시글 내용으로 게시글 검색")
+    void findArticlesWithFilesAndUserByBoardAndKeywordForArticleContent() {
+        //when
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
+        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByBoardAndKeywordForArticleContent(boards[0], pageable, "키워드");
+
+        //then
+        List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
+        assertThat(searchedArticlesIds).hasSameElementsAs(Arrays.asList(articles[0][0].getId(), articles[0][1].getId()));
+    }
+
+    @Test
+    @DisplayName("특정 게시판에서 게시글 제목+내용으로 게시글 검색")
+    void findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitleAndArticleContent() {
+        //when
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
+        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitleAndArticleContent(boards[1], pageable, "키워드");
+
+        //then
+        List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
+        assertThat(searchedArticlesIds).hasSameElementsAs(Arrays.asList(articles[1][0].getId(), articles[1][1].getId(), articles[1][3].getId()));
+    }
+
+    // ------------------------ 전체 게시판 게시글 검색 테스트 ----------------------------
+
+    @Test
+    @DisplayName("전체 게시판에서 작성자 학번으로 게시글 검색")
+    void findArticlesWithFilesAndUserByWriterStudentId() {
+        //when
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
+        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByWriterStudentId(pageable, users[0].getStudentId());
+
+        //then
+        List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
+        List<Long> expectedElements = new ArrayList<>();
+        for (int i = 0; i < boards.length; i++) {
+            expectedElements.add(articles[i][0].getId());
+            expectedElements.add(articles[i][2].getId());
+        }
+        assertThat(searchedArticlesIds).hasSameElementsAs(expectedElements);
+    }
+
+    @Test
+    @DisplayName("전체 게시판에서 작성자 이름으로 게시글 검색")
+    void findArticlesWithFilesAndUserByWriterUsername() {
+        //when
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
+        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByWriterUsername(pageable, users[1].getUsername());
+
+        //then
+        List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
+        List<Long> expectedElements = new ArrayList<>();
+        for (int i = 0; i < boards.length; i++) {
+            expectedElements.add(articles[i][1].getId());
+            expectedElements.add(articles[i][3].getId());
+        }
+        assertThat(searchedArticlesIds).hasSameElementsAs(expectedElements);
+    }
+
+    @Test
+    @DisplayName("전체 게시판에서 게시글 제목으로 게시글 검색")
+    void findArticlesWithFilesAndUserByKeywordForArticleTitle() {
+        //when
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
+        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByKeywordForArticleTitle(pageable, "키워드");
+
+        //then
+        List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
+        List<Long> expectedElements = new ArrayList<>();
+        for (int i = 0; i < boards.length; i++) {
+            expectedElements.add(articles[i][1].getId());
+            expectedElements.add(articles[i][3].getId());
+        }
+        assertThat(searchedArticlesIds).hasSameElementsAs(expectedElements);
+    }
+
+    @Test
+    @DisplayName("전체 게시판에서 게시글 내용으로 게시글 검색")
+    void findArticlesWithFilesAndUserByKeywordForArticleContent() {
+        //when
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
+        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByKeywordForArticleContent(pageable, "키워드");
+
+        //then
+        List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
+        List<Long> expectedElements = new ArrayList<>();
+        for (int i = 0; i < boards.length; i++) {
+            expectedElements.add(articles[i][0].getId());
+            expectedElements.add(articles[i][1].getId());
+        }
+        assertThat(searchedArticlesIds).hasSameElementsAs(expectedElements);
+    }
+
+    @Test
+    @DisplayName("전체 게시판에서 게시글 제목+내용으로 게시글 검색")
+    void findArticlesWithFilesAndUserByKeywordForArticleTitleAndArticleContent() {
+        //when
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
+        List<Article> searchedArticles = articleRepository.findArticlesWithFilesAndUserByKeywordForArticleTitleAndArticleContent(pageable, "키워드");
+
+        //then
+        List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
+        List<Long> expectedElements = new ArrayList<>();
+        for (int i = 0; i < boards.length; i++) {
+            expectedElements.add(articles[i][0].getId());
+            expectedElements.add(articles[i][1].getId());
+            expectedElements.add(articles[i][3].getId());
+        }
+        assertThat(searchedArticlesIds).hasSameElementsAs(expectedElements);
+    }
+}


### PR DESCRIPTION
## 👀 이슈

resolve #46 

## 📌 개요

게시글 검색 기능 추가

## 👩‍💻 작업 사항

- 전체, 게시판별로 다음과 같은 기준으로 검색할 수 있습니다.
  - 글쓴이 username
  - 글쓴이 학번
  - 제목+내용
  - 제목
  - 내용

- 관련 테스트 케이스 추가

## ✅ 참고 사항

이번에 추가한 articleRepository에서 메소드 이름이 너무 긴 것 같은데 어떻게 하는게 좋을까요?

예를 들어서 `findArticlesWithFilesAndUserByBoardAndKeywordForArticleContent
` -> `searchArticlesByBoardAndContent` 이런 식으로 줄여서 쓰는게 더 좋을까요?
