### PR TITLE
fix: 회원 정보 수정 기능 client에 맞게 수정 (#58)

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/domain/User.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/User.java
@@ -1,5 +1,6 @@
 package com.sammaru5.sammaru.domain;
 
+import com.sammaru5.sammaru.web.request.UserRequest;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -59,5 +60,11 @@ public class User {
 
     public void setPoint(Long point) {
         this.point = point;
+    }
+
+    public void modifyUserInfo(UserRequest userRequest, PasswordEncoder passwordEncoder) {
+        this.username = userRequest.getUsername();
+        this.email = userRequest.getEmail();
+        this.password = passwordEncoder.encode(userRequest.getPassword());
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserModifyService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserModifyService.java
@@ -26,9 +26,7 @@ public class UserModifyService {
             throw new CustomException(ErrorCode.ALREADY_EXIST_EMAIL, userRequest.getEmail());
         }
 
-        user.setUsername(userRequest.getUsername());
-        user.setEmail(userRequest.getEmail());
-        user.setPassword(passwordEncoder.encode(userRequest.getPassword()));
+        user.modifyUserInfo(userRequest, passwordEncoder);
         return new UserDTO(userRepository.save(user));
     }
 

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserModifyService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserModifyService.java
@@ -14,29 +14,25 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@Service @RequiredArgsConstructor
+@Service
+@RequiredArgsConstructor
 public class UserModifyService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
     public UserDTO modifyUser(User user, UserRequest userRequest) {
-        if (userRequest.getUsername() != null) {
-            user.setUsername(userRequest.getUsername());
+        if (!user.getEmail().equals(userRequest.getEmail()) && userRepository.existsByEmail(userRequest.getEmail())) {
+            throw new CustomException(ErrorCode.ALREADY_EXIST_EMAIL, userRequest.getEmail());
         }
-        if (userRequest.getEmail() != null) {
-            if (userRepository.existsByEmail(userRequest.getEmail())) {
-                throw new CustomException(ErrorCode.ALREADY_EXIST_EMAIL, userRequest.getEmail());
-            }
-            user.setEmail(userRequest.getEmail());
-        }
-        if (userRequest.getPassword() != null) {
-            user.setPassword(passwordEncoder.encode(userRequest.getPassword()));
-        }
+
+        user.setUsername(userRequest.getUsername());
+        user.setEmail(userRequest.getEmail());
+        user.setPassword(passwordEncoder.encode(userRequest.getPassword()));
         return new UserDTO(userRepository.save(user));
     }
 
-    public UserDTO modifyUserRole(Long userId, UserAuthority role){
+    public UserDTO modifyUserRole(Long userId, UserAuthority role) {
         User user = userRepository.findById(userId).get();
         user.setRole(role);
         return new UserDTO(userRepository.save(user));
@@ -44,7 +40,7 @@ public class UserModifyService {
 
     public UserDTO addUserPoint(Long userId, PointRequest pointRequest) throws CustomException {
         User user = userRepository.getById(userId);
-        if(user.getPoint() + pointRequest.getAddPoint() < 0){
+        if (user.getPoint() + pointRequest.getAddPoint() < 0) {
             throw new CustomException(ErrorCode.USER_POINT_CANT_NEGATIVE, userId.toString());
         }
         user.setPoint(user.getPoint() + pointRequest.getAddPoint());

--- a/src/main/java/com/sammaru5/sammaru/web/request/UserRequest.java
+++ b/src/main/java/com/sammaru5/sammaru/web/request/UserRequest.java
@@ -3,13 +3,20 @@ package com.sammaru5.sammaru.web.request;
 import lombok.Getter;
 
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 
 @Getter
 public class UserRequest {
+
+    @NotBlank(message = "이름은 필수 입력입니다")
     private String username;
+
+    @NotBlank(message = "비밀번호는 필수 입력입니다")
     @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}", message = "비밀번호는 8~20자로 영문, 숫자, 특수문자를 적어도 하나 사용해야 됩니다")
     private String password;
+
+    @NotBlank(message = "이메일은 필수 입력입니다")
     @Email(message = "이메일은 이메일 형식에 맞아야 됩니다")
     private String email;
 }


### PR DESCRIPTION
## 👀 이슈

resolve #58

## 📌 개요

회원 정보 수정 요청이 들어올때 수정되지 않은 항목은 기존 값으로 전달되는 경우를 기준으로 동작하도록 수정

## 👩‍💻 작업 사항

- `UserModifyService.modifyUser()` 수정

  - email 중복 검사에 기존 email과 동일한지 검사하는 조건문 추가
  - 항목별로 `null`인지 검사하는 조건문들 제거

- `UserRequest` class에 `@NotBlank` 추가

## ✅ 참고 사항
