### PR TITLE
fix : 자기 자신의 회원 정보 조회 API를 임시 회원도 사용할 수 있게 변경

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/web/controller/user/UserController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/user/UserController.java
@@ -7,6 +7,7 @@ import com.sammaru5.sammaru.service.user.UserSearchService;
 import com.sammaru5.sammaru.util.AuthUser;
 import com.sammaru5.sammaru.util.OverAdminRole;
 import com.sammaru5.sammaru.util.OverMemberRole;
+import com.sammaru5.sammaru.util.OverTempRole;
 import com.sammaru5.sammaru.web.apiresult.ApiResult;
 import com.sammaru5.sammaru.web.dto.UserDTO;
 import com.sammaru5.sammaru.web.request.PointRequest;
@@ -44,8 +45,7 @@ public class UserController {
     }
 
     @ApiOperation(value = "자기 자신 회원 정보", notes = "자기 자신의 회원 정보 가져오기, 토큰만 보내면 됩니다.")
-    @OverMemberRole
-    @GetMapping("/api/user/info")
+    @GetMapping("/no-permit/api/user/info")
     public ApiResult<UserDTO> loginUserSelfDetail(@AuthUser User user) {
         return ApiResult.OK(new UserDTO(user));
     }


### PR DESCRIPTION
## 👀 이슈

resolve #62 

## 📌 개요

임시 회원은 메인페이지를 볼 수 없었던 문제 수정

## 👩‍💻 작업 사항

자기 자신 회원 정보 API의 호출 등급을 임시 회원도 사용할 수 있도록 변경

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
