### PR TITLE
fix: CustomException 발생시 Http Response의 Http Status Code가 해당 exception과 일치하도록 수정

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
+++ b/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
@@ -17,6 +17,9 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 회원은 존재하지 않습니다!"),
     INDELIBLE_BOARD(HttpStatus.BAD_REQUEST, "해당 게시판은 삭제할 수 없습니다!"),
     WRONG_SEARCH_SUBJECT(HttpStatus.BAD_REQUEST, "올바르지 않은 검색 주제입니다!"),
+    VALID_CHECK_FAIL(HttpStatus.BAD_REQUEST, "입력 값에 대한 유효성 검사가 실패했습니다!"),
+    NULL_POINTER_EXCEPTION(HttpStatus.BAD_REQUEST, "Null pointer exception 오류가 발생했습니다!"),
+    ILLEGAL_ARGUMENT_EXCEPTION(HttpStatus.BAD_REQUEST, "Illegal argument exception 오류가 발생했습니다!"),
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED_USER_ACCESS(HttpStatus.UNAUTHORIZED, "권한이 없는 사용자의 접근입니다!"),
@@ -24,6 +27,9 @@ public enum ErrorCode {
 
     // 403 FORBIDDEN
     USER_POINT_CANT_NEGATIVE(HttpStatus.FORBIDDEN, "사용자의 포인트는 음수가 될 수 없습니다!"),
+
+    // 406 NOT ACCEPTABLE
+    ACCESS_DENIED(HttpStatus.NOT_ACCEPTABLE, "접근이 거부되었습니다!"),
 
     // 409 CONFLICT
     ALREADY_EXIST_USER(HttpStatus.CONFLICT, "해당 학번의 사용자가 이미 존재합니다!"),

--- a/src/main/java/com/sammaru5/sammaru/web/controller/exception/ExceptionController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/exception/ExceptionController.java
@@ -3,6 +3,7 @@ package com.sammaru5.sammaru.web.controller.exception;
 import com.sammaru5.sammaru.exception.CustomException;
 import com.sammaru5.sammaru.web.apiresult.ApiResult;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,9 +13,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class ExceptionController {
 
     @ExceptionHandler(CustomException.class)
-    public ApiResult<?> handleCustomException(CustomException e) {
+    public ResponseEntity<?> handleCustomException(CustomException e) {
         e.printStackTrace();
-        return ApiResult.ERROR(e, e.getErrorCode().getHttpStatus());
+        return new ResponseEntity<>(
+                ApiResult.ERROR(e, e.getErrorCode().getHttpStatus()),
+                e.getErrorCode().getHttpStatus()
+        );
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class) //@Valid 검사

--- a/src/main/java/com/sammaru5/sammaru/web/controller/exception/ExceptionController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/exception/ExceptionController.java
@@ -15,10 +15,8 @@ public class ExceptionController {
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<?> handleCustomException(CustomException e) {
         e.printStackTrace();
-        return new ResponseEntity<>(
-                ApiResult.ERROR(e, e.getErrorCode().getHttpStatus()),
-                e.getErrorCode().getHttpStatus()
-        );
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(ApiResult.ERROR(e, e.getErrorCode().getHttpStatus()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class) //@Valid 검사

--- a/src/main/java/com/sammaru5/sammaru/web/controller/exception/ExceptionController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/exception/ExceptionController.java
@@ -1,6 +1,7 @@
 package com.sammaru5.sammaru.web.controller.exception;
 
 import com.sammaru5.sammaru.exception.CustomException;
+import com.sammaru5.sammaru.exception.ErrorCode;
 import com.sammaru5.sammaru.web.apiresult.ApiResult;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,26 +21,34 @@ public class ExceptionController {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class) //@Valid 검사
-    public ApiResult<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
+    public ResponseEntity<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
         e.printStackTrace();
-        return ApiResult.ERROR(e.getBindingResult().getAllErrors().get(0).getDefaultMessage(), HttpStatus.BAD_REQUEST);
+        CustomException ce = new CustomException(ErrorCode.VALID_CHECK_FAIL);
+        return ResponseEntity.status(ce.getErrorCode().getHttpStatus())
+                .body(ApiResult.ERROR(ce, ce.getErrorCode().getHttpStatus()));
     }
 
     @ExceptionHandler(AccessDeniedException.class)
-    public ApiResult<?> handleAccessDeniedException(AccessDeniedException e){
+    public ResponseEntity<?> handleAccessDeniedException(AccessDeniedException e){
         e.printStackTrace();
-        return ApiResult.ERROR(e, HttpStatus.NOT_ACCEPTABLE);
+        CustomException ce = new CustomException(ErrorCode.ACCESS_DENIED);
+        return ResponseEntity.status(ce.getErrorCode().getHttpStatus())
+                .body(ApiResult.ERROR(ce, ce.getErrorCode().getHttpStatus()));
     }
 
     @ExceptionHandler(NullPointerException.class)
-    public ApiResult<?> handleNullPointerException(NullPointerException e){
+    public ResponseEntity<?> handleNullPointerException(NullPointerException e){
         e.printStackTrace();
-        return ApiResult.ERROR(e, HttpStatus.BAD_REQUEST);
+        CustomException ce = new CustomException(ErrorCode.NULL_POINTER_EXCEPTION);
+        return ResponseEntity.status(ce.getErrorCode().getHttpStatus())
+                .body(ApiResult.ERROR(ce, ce.getErrorCode().getHttpStatus()));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ApiResult<?> handleIllegalArgumentException(IllegalArgumentException e){
+    public ResponseEntity<?> handleIllegalArgumentException(IllegalArgumentException e){
         e.printStackTrace();
-        return ApiResult.ERROR(e, HttpStatus.BAD_REQUEST);
+        CustomException ce = new CustomException(ErrorCode.ILLEGAL_ARGUMENT_EXCEPTION);
+        return ResponseEntity.status(ce.getErrorCode().getHttpStatus())
+                .body(ApiResult.ERROR(ce, ce.getErrorCode().getHttpStatus()));
     }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #68 

## 📌 개요

`Custom Exception`이 발생했을때 `http reponse`의 `status code`가 항상 `200 OK`로 반환됌

## 👩‍💻 작업 사항

`ExceptionHandler`에서 반환값으로 `ApiResult` 대신 `ResponseEntity`를 반환하도록 수정

## ✅ 참고 사항

기존에 `NullPointerException`이나 `AccessDeniedException` 등을 통해 처리되던 오류들이 `CustomException`을 통해 처리되도록 수정되었기 때문에

`ExceptionController`에서 `NullPointerException`이나 `AccessDeniedException` 등의 Exception handler가 더 이상 필요하지 않은 것 같은데 제거하는게 어떨까요?

아니면 만약을 대비해서 이 부분도 적절한 `http status code`를 반환하도록 수정하는게 좋을까요?