### PR TITLE
bug: Value Annotation 사용 필드에서 static 제거 (#80)

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/config/jwt/TokenProvider.java
+++ b/src/main/java/com/sammaru5/sammaru/config/jwt/TokenProvider.java
@@ -32,10 +32,10 @@ public class TokenProvider {
     private static final String BEARER_TYPE = "bearer";
 
     @Value("${app.jwtTokenValidTime}") //설정파일의 토큰 유효시간
-    private static long ACCESS_TOKEN_EXPIRE_TIME;
+    private long ACCESS_TOKEN_EXPIRE_TIME;
 
     @Value("${app.jwtRefreshTokenValidTime}") //리프레쉬 토큰 유효시간
-    private static long REFRESH_TOKEN_EXPIRE_TIME;
+    private long REFRESH_TOKEN_EXPIRE_TIME;
 
     private final Key key;
 


### PR DESCRIPTION
## 👀 이슈

resolve #80

## 📌 개요

로그인 관련 오류 해결

## 👩‍💻 작업 사항

`TokenProvider` 클래스에서 `ACCESS_TOKEN_EXPIRE_TIME `랑 `REFRESH_TOKEN_EXPIRE_TIME` 값을 설정 파일에서 `@Value`를 통해 가져오는 방식을 사용하는데 static 필드로 되어있어서 정상적으로 값이 주입되지 않는 문제가 발생하여 이 부분을 수정함

## ✅ 참고 사항

수정 전에 spring을 실행시켜보면 다음과 같은 로그 메시지를 확인할 수 있다.

<img width="1236" alt="Screen Shot 2022-09-02 at 8 20 00 PM" src="https://user-images.githubusercontent.com/74577693/188130461-3e55578f-0ba0-43fc-8de7-50453c50a328.png">

실제로 `REFRESH_TOKEN_EXPIRE_TIME` 값을 출력해보면 설정 파일의 값이 아닌 0이 들어가 있는 것을 확인할 수 있다

<img width="1236" alt="Screen Shot 2022-09-02 at 8 20 17 PM" src="https://user-images.githubusercontent.com/74577693/188130320-f265c45d-d3b7-475a-95a7-672f8afbc8bf.png">
