### PR TITLE
fix: username으로 검색 시, 검색 글자가 포함된 모든 users를 List로 출력되도록 수정

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/repository/UserRepository.java
+++ b/src/main/java/com/sammaru5/sammaru/repository/UserRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByUsername(String username);
+    List<User> findByUsernameContaining(String username);
 
     Optional<User> findByStudentId(String studentId);
     boolean existsByStudentId(String studentId);

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserSearchService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserSearchService.java
@@ -35,7 +35,7 @@ public class UserSearchService {
         return userRepository.findByGeneration(generationNum).stream().map(UserDTO::new).collect(Collectors.toList());
     }
 
-    public UserDTO findByUsername(String username) {
-        return new UserDTO(userRepository.findByUsername(username).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, username)));
+    public List<UserDTO> findByUsername(String username) {
+        return userRepository.findByUsernameContaining(username).stream().map(UserDTO::new).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/web/controller/user/UserController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/user/UserController.java
@@ -33,14 +33,14 @@ public class UserController {
     @ApiOperation(value = "유저 권한 변경", notes = "userId에 해당하는 유저 권한 변경")
     @OverAdminRole
     @PatchMapping("/api/users/{userId}/role")
-    public ApiResult<UserDTO> userRoleModify(@Valid  @RequestBody RoleRequest roleRequest, @PathVariable Long userId){
+    public ApiResult<UserDTO> userRoleModify(@Valid @RequestBody RoleRequest roleRequest, @PathVariable Long userId) {
         return ApiResult.OK(userModifyService.modifyUserRole(userId, roleRequest.getRole()));
     }
 
     @ApiOperation(value = "유저 포인트 추가", notes = "userId에 해당하는 유저 포인트 부여 (음수 가능)")
     @OverAdminRole
     @PostMapping("/api/users/{userId}/point")
-    public ApiResult<UserDTO> userPointAdd(@Valid @RequestBody PointRequest pointRequest, @PathVariable Long userId){
+    public ApiResult<UserDTO> userPointAdd(@Valid @RequestBody PointRequest pointRequest, @PathVariable Long userId) {
         return ApiResult.OK(userModifyService.addUserPoint(userId, pointRequest));
     }
 
@@ -74,7 +74,7 @@ public class UserController {
     @ApiOperation(value = "회원 정보 수정", notes = "회원 정보 수정하기")
     @OverMemberRole
     @PatchMapping("/api/user/info")
-    public ApiResult<UserDTO> userModify(@AuthUser User user, @Valid @RequestBody UserRequest userRequest){
+    public ApiResult<UserDTO> userModify(@AuthUser User user, @Valid @RequestBody UserRequest userRequest) {
         return ApiResult.OK(userModifyService.modifyUser(user, userRequest));
     }
 
@@ -88,7 +88,7 @@ public class UserController {
     @GetMapping("/api/users/detail")
     @ApiOperation(value = "username으로 회원 정보 조회", notes = "관리자 권한이 username으로 해당 회원의 정보를 조회합니다.")
     @OverAdminRole
-    public ApiResult<UserDTO> userDetailByUsername(@RequestParam String username) {
+    public ApiResult<List<UserDTO>> userDetailByUsername(@RequestParam String username) {
         return ApiResult.OK(userSearchService.findByUsername(username));
     }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #75 

## 📌 개요

username으로 회원 정보 조회 해결 

## 👩‍💻 작업 사항

- `findByUsernameContaining`을 이용해 검색 글자가 포함된 user들을 조회할 수 있도록 함.
- `List` 데이터형을 이용하여 검색 결과를 List 형태로 출력하도록 함.

## ✅ 참고 사항

