### PR TITLE
feat: 페이징 API 기능 추가

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/repository/ArticleRepository.java
+++ b/src/main/java/com/sammaru5/sammaru/repository/ArticleRepository.java
@@ -2,6 +2,7 @@ package com.sammaru5.sammaru.repository;
 
 import com.sammaru5.sammaru.domain.Article;
 import com.sammaru5.sammaru.domain.Board;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -20,7 +21,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board",
             countQuery = "select count(a) from Article a where a.board = :board")
-    List<Article> findArticlesWithFilesAndUserByBoard(@Param("board") Board board, Pageable pageable);
+    Page<Article> findArticlesWithFilesAndUserByBoard(@Param("board") Board board, Pageable pageable);
 
     @Query(value = "select a from Article a join fetch a.user where a.board = :board",
             countQuery = "select count(a) from Article a where a.board = :board")
@@ -48,44 +49,44 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board and a.user.studentId = :studentId",
             countQuery = "select count(a) from Article a where a.board = :board and a.user.studentId = :studentId")
-    List<Article> searchArticlesByBoardAndStudentId(@Param("board") Board board, Pageable pageable, @Param("studentId") String studentId);
+    Page<Article> searchArticlesByBoardAndStudentId(@Param("board") Board board, Pageable pageable, @Param("studentId") String studentId);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board and a.user.username = :username",
             countQuery = "select count(a) from Article a where a.board = :board and a.user.username = :username")
-    List<Article> searchArticlesByBoardAndUsername(@Param("board") Board board, Pageable pageable, @Param("username") String username);
+    Page<Article> searchArticlesByBoardAndUsername(@Param("board") Board board, Pageable pageable, @Param("username") String username);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board and a.title like %:keyword%",
             countQuery = "select count(a) from Article a where a.board = :board and a.title like %:keyword%")
-    List<Article> searchArticlesByBoardAndTitle(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
+    Page<Article> searchArticlesByBoardAndTitle(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.board = :board and a.content like %:keyword%",
             countQuery = "select count(a) from Article a where a.board = :board and a.content like %:keyword%")
-    List<Article> searchArticlesByBoardAndContent(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
+    Page<Article> searchArticlesByBoardAndContent(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where (a.board = :board) and (a.title like %:keyword% or a.content like %:keyword%)",
             countQuery = "select count(a) from Article a where (a.board = :board) and (a.title like %:keyword% or a.content like %:keyword%)")
-    List<Article> searchArticlesByBoardAndTitleAndContent(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
+    Page<Article> searchArticlesByBoardAndTitleAndContent(@Param("board") Board board, Pageable pageable, @Param("keyword") String keyword);
 
     // -------------------- 전체 게시판 게시글 검색 ------------------------
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.user.studentId = :studentId",
             countQuery = "select count(a) from Article a where a.user.studentId = :studentId")
-    List<Article> searchArticlesByStudentId(Pageable pageable, @Param("studentId") String studentId);
+    Page<Article> searchArticlesByStudentId(Pageable pageable, @Param("studentId") String studentId);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.user.username = :username",
             countQuery = "select count(a) from Article a where a.user.username = :username")
-    List<Article> searchArticlesByUsername(Pageable pageable, @Param("username") String username);
+    Page<Article> searchArticlesByUsername(Pageable pageable, @Param("username") String username);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.title like %:keyword%",
             countQuery = "select count(a) from Article a where a.title like %:keyword%")
-    List<Article> searchArticlesByTitle(Pageable pageable, @Param("keyword") String keyword);
+    Page<Article> searchArticlesByTitle(Pageable pageable, @Param("keyword") String keyword);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.content like %:keyword%",
             countQuery = "select count(a) from Article a where a.content like %:keyword%")
-    List<Article> searchArticlesByContent(Pageable pageable, @Param("keyword") String keyword);
+    Page<Article> searchArticlesByContent(Pageable pageable, @Param("keyword") String keyword);
 
     @Query(value = "select a from Article a left join fetch a.files join fetch a.user where a.title like %:keyword% or a.content like %:keyword%",
             countQuery = "select count(a) from Article a where a.title like %:keyword% or a.content like %:keyword%")
-    List<Article> searchArticlesByTitleAndContent(Pageable pageable, @Param("keyword") String keyword);
+    Page<Article> searchArticlesByTitleAndContent(Pageable pageable, @Param("keyword") String keyword);
 
 }

--- a/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
@@ -10,6 +10,7 @@ import com.sammaru5.sammaru.repository.BoardRepository;
 import com.sammaru5.sammaru.web.dto.ArticleDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -38,13 +39,12 @@ public class ArticleSearchService {
     }
 
     //boardId에 해당하는 게시판의 게시글들을 paging
-    public List<ArticleDTO> findArticlesByBoardIdAndPaging(Long boardId, Integer pageNum) {
+    public Page<ArticleDTO> findArticlesByBoardIdAndPaging(Long boardId, Integer pageNum) {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
         Pageable pageable = PageRequest.of(pageNum, 15, Sort.by("createTime").descending());
-        List<Article> articles = articleRepository.findArticlesWithFilesAndUserByBoard(board, pageable);
-
-        return articles.stream().map(ArticleDTO::toDto).collect(Collectors.toList());
+        Page<Article> articles = articleRepository.findArticlesWithFilesAndUserByBoard(board, pageable);
+        return articles.map(ArticleDTO::toDto);
     }
 
     //boardId에 해당하는 게시판에 달린 모든 게시글들 조회
@@ -70,12 +70,12 @@ public class ArticleSearchService {
         return findArticles.stream().map(ArticleDTO::toDto).collect(Collectors.toList());
     }
 
-    public List<ArticleDTO> findArticlesByBoardIdAndKeywordAndPaging(Long boardId, Integer pageNum, SearchSubject searchSubject, String keyword) {
+    public Page<ArticleDTO> findArticlesByBoardIdAndKeywordAndPaging(Long boardId, Integer pageNum, SearchSubject searchSubject, String keyword) {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
         Pageable pageable = PageRequest.of(pageNum, 15, Sort.by("createTime").descending());
 
-        List<Article> articles;
+        Page<Article> articles;
         switch (searchSubject) {
             case WRITER_STUDENT_ID:
                 articles = articleRepository.searchArticlesByBoardAndStudentId(board, pageable, keyword);
@@ -95,13 +95,13 @@ public class ArticleSearchService {
             default:
                 throw new CustomException(ErrorCode.WRONG_SEARCH_SUBJECT, searchSubject.name());
         }
-        return articles.stream().map(ArticleDTO::toDto).collect(Collectors.toList());
+        return articles.map(ArticleDTO::toDto);
     }
 
-    public List<ArticleDTO> findArticlesByKeywordAndPaging(Integer pageNum, SearchSubject searchSubject, String keyword) {
+    public Page<ArticleDTO> findArticlesByKeywordAndPaging(Integer pageNum, SearchSubject searchSubject, String keyword) {
         Pageable pageable = PageRequest.of(pageNum, 15, Sort.by("createTime").descending());
 
-        List<Article> articles;
+        Page<Article> articles;
         switch (searchSubject) {
             case WRITER_STUDENT_ID:
                 articles = articleRepository.searchArticlesByStudentId(pageable, keyword);
@@ -121,6 +121,6 @@ public class ArticleSearchService {
             default:
                 throw new CustomException(ErrorCode.WRONG_SEARCH_SUBJECT, searchSubject.name());
         }
-        return articles.stream().map(ArticleDTO::toDto).collect(Collectors.toList());
+        return articles.map(ArticleDTO::toDto);
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
@@ -39,10 +39,10 @@ public class ArticleSearchService {
     }
 
     //boardId에 해당하는 게시판의 게시글들을 paging
-    public Page<ArticleDTO> findArticlesByBoardIdAndPaging(Long boardId, Integer pageNum) {
+    public Page<ArticleDTO> findArticlesByBoardIdAndPaging(Long boardId, Integer pageNum, Integer pageSize) {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
-        Pageable pageable = PageRequest.of(pageNum, 15, Sort.by("createTime").descending());
+        Pageable pageable = PageRequest.of(pageNum, pageSize, Sort.by("createTime").descending());
         Page<Article> articles = articleRepository.findArticlesWithFilesAndUserByBoard(board, pageable);
         return articles.map(ArticleDTO::toDto);
     }
@@ -70,10 +70,10 @@ public class ArticleSearchService {
         return findArticles.stream().map(ArticleDTO::toDto).collect(Collectors.toList());
     }
 
-    public Page<ArticleDTO> findArticlesByBoardIdAndKeywordAndPaging(Long boardId, Integer pageNum, SearchSubject searchSubject, String keyword) {
+    public Page<ArticleDTO> findArticlesByBoardIdAndKeywordAndPaging(Long boardId, Integer pageNum, Integer pageSize, SearchSubject searchSubject, String keyword) {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
-        Pageable pageable = PageRequest.of(pageNum, 15, Sort.by("createTime").descending());
+        Pageable pageable = PageRequest.of(pageNum, pageSize, Sort.by("createTime").descending());
 
         Page<Article> articles;
         switch (searchSubject) {
@@ -98,8 +98,8 @@ public class ArticleSearchService {
         return articles.map(ArticleDTO::toDto);
     }
 
-    public Page<ArticleDTO> findArticlesByKeywordAndPaging(Integer pageNum, SearchSubject searchSubject, String keyword) {
-        Pageable pageable = PageRequest.of(pageNum, 15, Sort.by("createTime").descending());
+    public Page<ArticleDTO> findArticlesByKeywordAndPaging(Integer pageNum, Integer pageSize, SearchSubject searchSubject, String keyword) {
+        Pageable pageable = PageRequest.of(pageNum, pageSize, Sort.by("createTime").descending());
 
         Page<Article> articles;
         switch (searchSubject) {

--- a/src/main/java/com/sammaru5/sammaru/web/controller/board/BoardController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/board/BoardController.java
@@ -52,19 +52,19 @@ public class BoardController {
 
     @GetMapping("/no-permit/api/boards/{boardId}/pages/{pageNum}")
     @ApiOperation(value = "게시판 세부 정보 조회", notes = "해당 게시판의 게시글들을 조회 ex.자유게시판", responseContainer = "List", response = ArticleDTO.class)
-    public ApiResult<Page<ArticleDTO>> boardDetails(@PathVariable Long boardId, @PathVariable Integer pageNum) {
-        return ApiResult.OK(articleSearchService.findArticlesByBoardIdAndPaging(boardId, pageNum - 1));
+    public ApiResult<Page<ArticleDTO>> boardDetails(@PathVariable Long boardId, @PathVariable Integer pageNum, @RequestParam Integer pageSize) {
+        return ApiResult.OK(articleSearchService.findArticlesByBoardIdAndPaging(boardId, pageNum - 1, pageSize));
     }
 
     @GetMapping("/no-permit/api/boards/{boardId}/searchResult/pages/{pageNum}")
     @ApiOperation(value = "특정 게시판 검색", notes = "해당 게시판을 대상으로 게시글들을 검색 ex.자유게시판", responseContainer = "List", response = ArticleDTO.class)
-    public ApiResult<Page<ArticleDTO>> boardSearch(@PathVariable Long boardId, @PathVariable Integer pageNum, @RequestParam SearchSubject searchSubject, @RequestParam String keyword) {
-        return ApiResult.OK(articleSearchService.findArticlesByBoardIdAndKeywordAndPaging(boardId, pageNum - 1, searchSubject, keyword));
+    public ApiResult<Page<ArticleDTO>> boardSearch(@PathVariable Long boardId, @PathVariable Integer pageNum, @RequestParam Integer pageSize, @RequestParam SearchSubject searchSubject, @RequestParam String keyword) {
+        return ApiResult.OK(articleSearchService.findArticlesByBoardIdAndKeywordAndPaging(boardId, pageNum - 1, pageSize, searchSubject, keyword));
     }
 
     @GetMapping("/no-permit/api/boards/searchResult/pages/{pageNum}")
     @ApiOperation(value = "모든 게시판 검색", notes = "모든 게시판을 대상으로 게시글들을 검색", responseContainer = "List", response = ArticleDTO.class)
-    public ApiResult<Page<ArticleDTO>> search(@PathVariable Integer pageNum, @RequestParam SearchSubject searchSubject, @RequestParam String keyword) {
-        return ApiResult.OK(articleSearchService.findArticlesByKeywordAndPaging(pageNum - 1, searchSubject, keyword));
+    public ApiResult<Page<ArticleDTO>> search(@PathVariable Integer pageNum, @RequestParam Integer pageSize, @RequestParam SearchSubject searchSubject, @RequestParam String keyword) {
+        return ApiResult.OK(articleSearchService.findArticlesByKeywordAndPaging(pageNum - 1, pageSize, searchSubject, keyword));
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/web/controller/board/BoardController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/board/BoardController.java
@@ -1,19 +1,19 @@
 package com.sammaru5.sammaru.web.controller.board;
 
 import com.sammaru5.sammaru.domain.SearchSubject;
-import com.sammaru5.sammaru.util.OverAdminRole;
-import com.sammaru5.sammaru.util.OverMemberRole;
-import com.sammaru5.sammaru.web.apiresult.ApiResult;
-import com.sammaru5.sammaru.web.dto.ArticleDTO;
-import com.sammaru5.sammaru.web.dto.BoardDTO;
-import com.sammaru5.sammaru.web.request.BoardRequest;
 import com.sammaru5.sammaru.service.article.ArticleSearchService;
 import com.sammaru5.sammaru.service.board.BoardRegisterService;
 import com.sammaru5.sammaru.service.board.BoardRemoveService;
 import com.sammaru5.sammaru.service.board.BoardStatusService;
+import com.sammaru5.sammaru.util.OverAdminRole;
+import com.sammaru5.sammaru.web.apiresult.ApiResult;
+import com.sammaru5.sammaru.web.dto.ArticleDTO;
+import com.sammaru5.sammaru.web.dto.BoardDTO;
+import com.sammaru5.sammaru.web.request.BoardRequest;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -52,19 +52,19 @@ public class BoardController {
 
     @GetMapping("/no-permit/api/boards/{boardId}/pages/{pageNum}")
     @ApiOperation(value = "게시판 세부 정보 조회", notes = "해당 게시판의 게시글들을 조회 ex.자유게시판", responseContainer = "List", response = ArticleDTO.class)
-    public ApiResult<List<ArticleDTO>> boardDetails(@PathVariable Long boardId, @PathVariable Integer pageNum) {
+    public ApiResult<Page<ArticleDTO>> boardDetails(@PathVariable Long boardId, @PathVariable Integer pageNum) {
         return ApiResult.OK(articleSearchService.findArticlesByBoardIdAndPaging(boardId, pageNum - 1));
     }
 
     @GetMapping("/no-permit/api/boards/{boardId}/searchResult/pages/{pageNum}")
     @ApiOperation(value = "특정 게시판 검색", notes = "해당 게시판을 대상으로 게시글들을 검색 ex.자유게시판", responseContainer = "List", response = ArticleDTO.class)
-    public ApiResult<List<ArticleDTO>> boardSearch(@PathVariable Long boardId, @PathVariable Integer pageNum, @RequestParam SearchSubject searchSubject, @RequestParam String keyword) {
+    public ApiResult<Page<ArticleDTO>> boardSearch(@PathVariable Long boardId, @PathVariable Integer pageNum, @RequestParam SearchSubject searchSubject, @RequestParam String keyword) {
         return ApiResult.OK(articleSearchService.findArticlesByBoardIdAndKeywordAndPaging(boardId, pageNum - 1, searchSubject, keyword));
     }
 
     @GetMapping("/no-permit/api/boards/searchResult/pages/{pageNum}")
     @ApiOperation(value = "모든 게시판 검색", notes = "모든 게시판을 대상으로 게시글들을 검색", responseContainer = "List", response = ArticleDTO.class)
-    public ApiResult<List<ArticleDTO>> search(@PathVariable Integer pageNum, @RequestParam SearchSubject searchSubject, @RequestParam String keyword) {
+    public ApiResult<Page<ArticleDTO>> search(@PathVariable Integer pageNum, @RequestParam SearchSubject searchSubject, @RequestParam String keyword) {
         return ApiResult.OK(articleSearchService.findArticlesByKeywordAndPaging(pageNum - 1, searchSubject, keyword));
     }
 }

--- a/src/test/java/com/sammaru5/sammaru/repository/ArticleRepositoryTest.java
+++ b/src/test/java/com/sammaru5/sammaru/repository/ArticleRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -18,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class ArticleRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/sammaru5/sammaru/repository/ArticlesSearchTest.java
+++ b/src/test/java/com/sammaru5/sammaru/repository/ArticlesSearchTest.java
@@ -73,7 +73,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByBoardAndWriterStudentId() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndStudentId(boards[0], pageable, users[0].getStudentId());
+        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndStudentId(boards[0], pageable, users[0].getStudentId()).getContent();
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -85,7 +85,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByBoardAndWriterUsername() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndUsername(boards[1], pageable, users[1].getUsername());
+        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndUsername(boards[1], pageable, users[1].getUsername()).getContent();
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -97,7 +97,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitle() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndTitle(boards[2], pageable, "키워드");
+        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndTitle(boards[2], pageable, "키워드").getContent();
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -109,7 +109,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByBoardAndKeywordForArticleContent() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndContent(boards[0], pageable, "키워드");
+        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndContent(boards[0], pageable, "키워드").getContent();
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -121,7 +121,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByBoardAndKeywordForArticleTitleAndArticleContent() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndTitleAndContent(boards[1], pageable, "키워드");
+        List<Article> searchedArticles = articleRepository.searchArticlesByBoardAndTitleAndContent(boards[1], pageable, "키워드").getContent();
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -135,7 +135,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByWriterStudentId() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.searchArticlesByStudentId(pageable, users[0].getStudentId());
+        List<Article> searchedArticles = articleRepository.searchArticlesByStudentId(pageable, users[0].getStudentId()).getContent();
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -152,7 +152,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByWriterUsername() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.searchArticlesByUsername(pageable, users[1].getUsername());
+        List<Article> searchedArticles = articleRepository.searchArticlesByUsername(pageable, users[1].getUsername()).getContent();
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -169,7 +169,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByKeywordForArticleTitle() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.searchArticlesByTitle(pageable, "키워드");
+        List<Article> searchedArticles = articleRepository.searchArticlesByTitle(pageable, "키워드").getContent();
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -186,7 +186,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByKeywordForArticleContent() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.searchArticlesByContent(pageable, "키워드");
+        List<Article> searchedArticles = articleRepository.searchArticlesByContent(pageable, "키워드").getContent();
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());
@@ -203,7 +203,7 @@ class ArticlesSearchTest {
     void findArticlesWithFilesAndUserByKeywordForArticleTitleAndArticleContent() {
         //when
         Pageable pageable = PageRequest.of(0, 15, Sort.by("createTime").descending());
-        List<Article> searchedArticles = articleRepository.searchArticlesByTitleAndContent(pageable, "키워드");
+        List<Article> searchedArticles = articleRepository.searchArticlesByTitleAndContent(pageable, "키워드").getContent();
 
         //then
         List<Long> searchedArticlesIds = searchedArticles.stream().map(Article::getId).collect(Collectors.toList());

--- a/src/test/java/com/sammaru5/sammaru/repository/ArticlesSearchTest.java
+++ b/src/test/java/com/sammaru5/sammaru/repository/ArticlesSearchTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -24,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class ArticlesSearchTest {
 
     @Autowired


### PR DESCRIPTION
## 👀 이슈

resolve #82 

## 📌 개요

Client 측에서 게시판 pagination 관련 기능을 제작하기 위해 필요하다고 요청한 기능

## 👩‍💻 작업 사항

- 게시글을 Paging 하는 요청의 경우, List 대신 Page 객체를 반환함으로써 총 페이지 수, 총 게시글 수 등의 정보를 Client 측에서 확인할 수 있도록 수정
- query parameter로 페이지 당 게시글 개수를 입력받을 수 있도록 수정

## ✅ 참고 사항

### 변경된 API
- /no-permit/api/boards/{boardId}/pages/{pageNum}
- /no-permit/api/boards/{boardId}/searchResult/pages/{pageNum}
- /no-permit/api/boards/searchResult/pages/{pageNum}

### Response 구조 변경 설명

> Swgger에서 변경된 API들 참고

기존에는 게시글만 response에 담겨있었는데 다음과 같이 수정되었다.

1. 게시글은 content 안에 묶여서 들어간다.

<img width="607" alt="Screen Shot 2022-09-04 at 11 01 34 AM" src="https://user-images.githubusercontent.com/74577693/188294473-6d81b8ce-c901-4516-9a8a-fbc186f227dd.png">

2. 그리고 reponse 안에 다음과 같은 항목들이 추가되었다.

- `totalPage` : 총 페이지 수
- `totalElements` : 총 게시글 수
- `last` : 마지막 페이지인지 여부
- `size` : 한 페이지 당 게시글 수
- `number` : 현재 페이지 number, 0부터 시작

<img width="607" alt="Screen Shot 2022-09-04 at 11 00 47 AM" src="https://user-images.githubusercontent.com/74577693/188294481-b79a6084-a551-4056-8bc9-d383b5d5a7d5.png">
