### PR TITLE
fix: request가 들어왔을 때 AccessToken 값을 Cookie가 아닌 header에서 확인하도록 변경

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sammaru5/sammaru/config/jwt/JwtAuthenticationFilter.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 @AllArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
     private final TokenProvider tokenProvider;
 
     @Override
@@ -35,11 +37,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String resolveToken(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null) return null;
-        for (Cookie cookie : cookies) {
-            if (!cookie.getName().equals("SammaruAccessToken")) continue;
-            return cookie.getValue();
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
         }
         return null;
     }


### PR DESCRIPTION
## 👀 이슈

resolve #84

## 📌 개요

AccessToken을 확인하는 방식도 header에서 Cookie로 바뀌었다고 착각해서 변경했던 부분 수정

## 👩‍💻 작업 사항

다시 header에서 accessToken 값을 확인하도록 변경

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
