### PR TITLE
fix: 빈 게시판을 조회하더라도 400 error가 발생하지 않고 200 OK로 빈 배열을 반환하도록 수정

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
+++ b/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
@@ -11,7 +11,6 @@ public enum ErrorCode {
     // 400 BAD REQUEST
     ARTICLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 게시글은 존재하지 않습니다!"),
     BOARD_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 게시판은 존재하지 않습니다!"),
-    BOARD_IS_EMPTY(HttpStatus.BAD_REQUEST, "해당 게시판에 게시글이 존재하지 않습니다!"),
     COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 댓글은 존재하지 않습니다!"),
     FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 파일은 존재하지 않습니다!"),
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 회원은 존재하지 않습니다!"),

--- a/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
@@ -50,10 +50,6 @@ public class ArticleSearchService {
     //boardId에 해당하는 게시판에 달린 모든 게시글들 조회
     public List<ArticleDTO> findArticlesByBoardId(Long boardId) {
         List<Article> findArticles = articleRepository.findArticlesByBoardId(boardId);
-        if (findArticles.isEmpty()) {
-            throw new CustomException(ErrorCode.BOARD_IS_EMPTY, boardId.toString());
-        }
-
         return findArticles.stream().map(ArticleDTO::toDto).collect(Collectors.toList());
     }
 
@@ -63,10 +59,6 @@ public class ArticleSearchService {
                 .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
         Pageable pageable = PageRequest.of(0, 7, Sort.by("createTime").descending());
         List<Article> findArticles = articleRepository.findByBoard(board, pageable);
-        if (findArticles.isEmpty()) {
-            throw new CustomException(ErrorCode.BOARD_IS_EMPTY, board.getId().toString());
-        }
-
         return findArticles.stream().map(ArticleDTO::toDto).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## 👀 이슈

resolve #92

## 📌 개요

기존에 게시글이 없는 게시판을 조회하면 400 error가 발생하도록 했는데, 이는 부적절하다고 판단됌

## 👩‍💻 작업 사항

빈 게시판을 조회하더라도 400 error가 발생하지 않고 200 OK로 빈 배열을 반환하도록 수정

## ✅ 참고 사항
