### PR TITLE
fix: 임시 회원 로그인시 발생하는 에러 코드 수정

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/config/jwt/TokenProvider.java
+++ b/src/main/java/com/sammaru5/sammaru/config/jwt/TokenProvider.java
@@ -50,7 +50,7 @@ public class TokenProvider {
                 .collect(Collectors.joining(","));
 
         if (authorities.contains(UserAuthority.ROLE_TEMP.toString()))
-            throw new CustomException(ErrorCode.UNAUTHORIZED_USER_ACCESS);
+            throw new CustomException(ErrorCode.USER_IS_TEMP_ACCOUNT);
 
         long now = (new Date()).getTime();
 

--- a/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
+++ b/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
 
     // 403 FORBIDDEN
     USER_POINT_CANT_NEGATIVE(HttpStatus.FORBIDDEN, "사용자의 포인트는 음수가 될 수 없습니다!"),
+    USER_IS_TEMP_ACCOUNT(HttpStatus.FORBIDDEN, "임시 회원은 관리자가 승인하기 전까지 로그인 할 수 없습니다!"),
 
     // 406 NOT ACCEPTABLE
     ACCESS_DENIED(HttpStatus.NOT_ACCEPTABLE, "접근이 거부되었습니다!"),


### PR DESCRIPTION
## 👀 이슈

resolve #107 

## 📌 개요

기존에 임시 회원 로그인 시 `ErrorCode.UNAUTHORIZED_USER_ACCESS`를 반환하도록 되어있었는데,

다른 오류와 명확하게 구분도 안되고, 401보다는 403이 적합하다고 판단되어 새로운 ErrorCode 추가

## 👩‍💻 작업 사항

- `ErrorCode.USER_IS_TEMP_ACCOUNT` 추가
- 임시 회원 로그인 시 해당 ErrorCode 반환하도록 변경

## ✅ 참고 사항

<img width="648" alt="Screen Shot 2022-09-21 at 10 10 05 PM" src="https://user-images.githubusercontent.com/74577693/191512582-94ed24de-0071-4182-bc6f-22def76f559b.png">
