### PR TITLE
feat: 로그아웃 API 추가

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/config/SwaggerConfig.java
+++ b/src/main/java/com/sammaru5/sammaru/config/SwaggerConfig.java
@@ -7,9 +7,16 @@ import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.Collections;
+import java.util.List;
 
 @EnableSwagger2
 @Configuration
@@ -28,10 +35,33 @@ public class SwaggerConfig {
     public Docket restAPI() {
         return new Docket(DocumentationType.SWAGGER_2)
                 .apiInfo(apiInfo())
+                .securityContexts(Collections.singletonList(securityContext()))
+                .securitySchemes(List.of(apiKey()))
                 .select()
                 .apis(RequestHandlerSelectors.basePackage("com.sammaru5.sammaru.web.controller"))
                 .paths(PathSelectors.any()) //어떤 식으로 시작하는 api를 보여줄것인가
                 .build();
+    }
+
+    private ApiKey apiKey() {
+        return new ApiKey("JWT", "Authorization", "header");
+    }
+
+    private SecurityContext securityContext() {
+        return springfox
+                .documentation
+                .spi.service
+                .contexts
+                .SecurityContext
+                .builder()
+                .securityReferences(defaultAuth()).forPaths(PathSelectors.any()).build();
+    }
+
+    List<SecurityReference> defaultAuth() {
+        AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = authorizationScope;
+        return List.of(new SecurityReference("JWT", authorizationScopes));
     }
 
     public ApiInfo apiInfo() {

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserLogoutService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserLogoutService.java
@@ -1,0 +1,28 @@
+package com.sammaru5.sammaru.service.user;
+
+import com.sammaru5.sammaru.exception.CustomException;
+import com.sammaru5.sammaru.exception.ErrorCode;
+import com.sammaru5.sammaru.repository.UserRepository;
+import com.sammaru5.sammaru.util.redis.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class UserLogoutService {
+    private final UserRepository userRepository;
+    private final RedisUtil redisUtil;
+
+    public Boolean deleteRefreshToken(Long userId) {
+
+        if (!userRepository.existsById(userId)) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND, userId.toString());
+        }
+
+        redisUtil.deleteData("RT:" + userId);
+
+        return true;
+    }
+}


### PR DESCRIPTION
## 👀 이슈

resolve #110

## 📌 개요

로그아웃 API 추가

## 👩‍💻 작업 사항

- 로그아웃 요청시 Redis에 저장된 RefreshToken 삭제
    > AccessToken은 만료되기 전까진 따로 비활성화할 수 있는 방법이 없음.
    > AccessToken을 일일히 따로 저장해서 관리한다면 가능하겠지만 리소스가 많이 사용될테고, jwt의 취지에 맞지 않음
- 로그아웃 요청시 set-cookie에 max-age를 0으로 설정해서 보냄으로써 클라이언트에 저장된 쿠키가 삭제되도록 구현
- Swagger에서 테스트시 Authorization 헤더 설정할 수 있는 기능 추가

## ✅ 참고 사항 - Swagger UI 인증 사용 방법

Swagger UI에서 `Authorize` 버튼 클릭 후

<img width="587" alt="image" src="https://user-images.githubusercontent.com/74577693/191645221-d3621580-ee64-4f56-8db4-7d55de8789ce.png">

그림과 같이 AccessToken 앞에 `Bearer `를 붙여서 입력하고 `Authorize` 버튼을 눌러서 사용하시면 됩니다.

<img width="779" alt="image" src="https://user-images.githubusercontent.com/74577693/191645345-380fb5ba-4696-4f61-a645-1c8d40a402f9.png">
