### PR TITLE
fix: CommentDTO수정 (createDt, author추가)

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/web/dto/CommentDTO.java
+++ b/src/main/java/com/sammaru5/sammaru/web/dto/CommentDTO.java
@@ -4,15 +4,19 @@ import com.sammaru5.sammaru.domain.Comment;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import java.sql.Timestamp;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentDTO {
     private Long id;
     private String content;
-
+    private Timestamp createDt;
+    private String author;
     public CommentDTO(Comment comment) {
         this.id = comment.getId();
         this.content = comment.getContent();
+        this.createDt = comment.getCreateTime();
+        this.author =comment.getUser().getUsername();
     }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #112 

## 📌 개요
* api : /api/boards/{boardId}/articles/{articleId}/comments 요청시 id와 content만 데이터 제공*
* 댓글 작성자, 작성일자도 제공

## 👩‍💻 작업 사항

* 작성자, 작성일자 제공하게끔 CommentDTO 수정 

## ✅ 참고 사항
![image](https://user-images.githubusercontent.com/77261327/192428295-20d319a4-ffce-4117-b9d4-7f19f6fe2246.png)
