### PR TITLE
refactor: 게시글 생성 및 수정 API의 반환을 DTO로 변경

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/service/article/ArticleModifyService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/article/ArticleModifyService.java
@@ -7,6 +7,7 @@ import com.sammaru5.sammaru.exception.CustomException;
 import com.sammaru5.sammaru.exception.ErrorCode;
 import com.sammaru5.sammaru.repository.ArticleRepository;
 import com.sammaru5.sammaru.repository.UserRepository;
+import com.sammaru5.sammaru.web.dto.ArticleDTO;
 import com.sammaru5.sammaru.web.request.ArticleRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,7 +27,7 @@ public class ArticleModifyService {
     private String fileDir;
 
     @CacheEvict(keyGenerator = "articleCacheKeyGenerator", value = "article", cacheManager = "cacheManager")
-    public Long modifyArticle(Long articleId, Long userId, Long boardId, ArticleRequest articleRequest, MultipartFile[] multipartFiles) {
+    public ArticleDTO modifyArticle(Long articleId, Long userId, Long boardId, ArticleRequest articleRequest, MultipartFile[] multipartFiles) {
         User findUser = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, userId.toString()));
         Article article = articleRepository.findById(articleId)
@@ -40,11 +41,11 @@ public class ArticleModifyService {
 
         if (multipartFiles != null) {
             article.removeFile();
-            for(MultipartFile multipartFile : multipartFiles) {
+            for (MultipartFile multipartFile : multipartFiles) {
                 article.addFile(File.createFile(multipartFile, fileDir, boardId));
             }
         }
-        return articleId;
-    }
 
+        return ArticleDTO.toDto(articleRepository.save(article));
+    }
 }

--- a/src/main/java/com/sammaru5/sammaru/service/article/ArticleRegisterService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/article/ArticleRegisterService.java
@@ -1,14 +1,12 @@
 package com.sammaru5.sammaru.service.article;
 
-import com.sammaru5.sammaru.domain.Article;
-import com.sammaru5.sammaru.domain.Board;
-import com.sammaru5.sammaru.domain.File;
-import com.sammaru5.sammaru.domain.User;
+import com.sammaru5.sammaru.domain.*;
 import com.sammaru5.sammaru.exception.CustomException;
 import com.sammaru5.sammaru.exception.ErrorCode;
 import com.sammaru5.sammaru.repository.ArticleRepository;
 import com.sammaru5.sammaru.repository.BoardRepository;
 import com.sammaru5.sammaru.repository.UserRepository;
+import com.sammaru5.sammaru.web.dto.ArticleDTO;
 import com.sammaru5.sammaru.web.request.ArticleRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,7 +25,7 @@ public class ArticleRegisterService {
     @Value("${app.fileDir}")
     private String fileDir;
 
-    public Long addArticle(Long userId, Long boardId, ArticleRequest articleRequest, MultipartFile[] multipartFiles) {
+    public ArticleDTO addArticle(Long userId, Long boardId, ArticleRequest articleRequest, MultipartFile[] multipartFiles) {
         User findUser = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, userId.toString()));
         Board board = boardRepository.findById(boardId)
@@ -41,6 +39,6 @@ public class ArticleRegisterService {
             }
         }
 
-        return articleRepository.save(article).getId();
+        return ArticleDTO.toDto(articleRepository.save(article));
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/web/controller/article/ArticleController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/article/ArticleController.java
@@ -34,7 +34,7 @@ public class ArticleController {
     @PostMapping(value = "/api/boards/{boardId}/articles", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     @ApiOperation(value = "게시글 생성", notes = "게시판에 게시글 추가")
     @OverMemberRole
-    public ApiResult<Long> articleAdd(@PathVariable Long boardId, @RequestPart(value = "article") @Valid ArticleRequest articleRequest, @RequestPart(value = "file", required = false) MultipartFile[] multipartFiles) {
+    public ApiResult<ArticleDTO> articleAdd(@PathVariable Long boardId, @RequestPart(value = "article") @Valid ArticleRequest articleRequest, @RequestPart(value = "file", required = false) MultipartFile[] multipartFiles) {
         return ApiResult.OK(articleRegisterService.addArticle(SecurityUtil.getCurrentUserId(), boardId, articleRequest, multipartFiles));
     }
 
@@ -55,7 +55,7 @@ public class ArticleController {
     @PatchMapping(value = "/api/boards/{boardId}/articles/{articleId}", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     @ApiOperation(value = "게시글 수정", notes = "작성자가 게시글 수정")
     @OverMemberRole
-    public ApiResult<Long> articleModify(@PathVariable Long boardId, @PathVariable Long articleId, @RequestPart(value = "article", required = false) @Valid ArticleRequest articleRequest, @RequestPart(value = "file", required = false) MultipartFile[] multipartFiles) {
+    public ApiResult<ArticleDTO> articleModify(@PathVariable Long boardId, @PathVariable Long articleId, @RequestPart(value = "article", required = false) @Valid ArticleRequest articleRequest, @RequestPart(value = "file", required = false) MultipartFile[] multipartFiles) {
         return ApiResult.OK(articleModifyService.modifyArticle(articleId, SecurityUtil.getCurrentUserId(), boardId, articleRequest, multipartFiles));
     }
 


### PR DESCRIPTION
## 👀 이슈

resolve #118 

## 📌 개요

게시글 생성 및 수정 API에서 DTO 반환으로 수정하여, 해당 데이터가 필요할 시 수정 요청 response에서 변경된 객체를 꺼내서 쓰면 되기에 네트워크 요청을 추가로 보낼 필요가 없다는 장점이 있다.

## 👩‍💻 작업 사항

- 게시글 생성 및 수정 API에서 DTO를 반환하도록 수정 (id -> DTO)

## ✅ 참고 사항

