### PR TITLE
fix: 게시글 삭제하기전 관련 댓글부터 삭제하도록 수정

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/repository/CommentRepository.java
+++ b/src/main/java/com/sammaru5/sammaru/repository/CommentRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByArticle(Article article);
+
+    void deleteAllByArticleId(Long articleId);
 }

--- a/src/main/java/com/sammaru5/sammaru/service/article/ArticleRemoveService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/article/ArticleRemoveService.java
@@ -6,6 +6,7 @@ import com.sammaru5.sammaru.exception.CustomException;
 import com.sammaru5.sammaru.exception.ErrorCode;
 import com.sammaru5.sammaru.repository.ArticleLikeRepository;
 import com.sammaru5.sammaru.repository.ArticleRepository;
+import com.sammaru5.sammaru.repository.CommentRepository;
 import com.sammaru5.sammaru.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
@@ -20,6 +21,7 @@ public class ArticleRemoveService {
     private final ArticleRepository articleRepository;
     private final UserRepository userRepository;
     private final ArticleLikeRepository articleLikeRepository;
+    private final CommentRepository commentRepository;
 
     @CacheEvict(keyGenerator = "articleCacheKeyGenerator", value = "article", cacheManager = "cacheManager")
     public boolean removeArticle(Long articleId, Long userId, Long boardId) {
@@ -33,6 +35,7 @@ public class ArticleRemoveService {
         }
 
         articleLikeRepository.deleteAllByArticleId(articleId);
+        commentRepository.deleteAllByArticleId(articleId);
 
         articleRepository.delete(article);
         return true;


### PR DESCRIPTION
## 👀 이슈

resolve #120

## 📌 개요

게시글 삭제 오류 수정

## 👩‍💻 작업 사항

- 게시글을 삭제하기 전 해당 게시글의 댓글부터 모두 삭제하도록 수정
- 관련 테스트 추가

## ✅ 참고 사항

`cascadingType`을 통해서 설정해주는게 코드가 더 간결할 것 같지만, 아직 공부가 필요한 부분이라 추후에 수정할 예정