### PR TITLE
refactor: 게시판 조회 서비스 이름 변경

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/service/board/BoardSearchService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/board/BoardSearchService.java
@@ -1,8 +1,6 @@
 package com.sammaru5.sammaru.service.board;
 
 import com.sammaru5.sammaru.domain.Board;
-import com.sammaru5.sammaru.exception.CustomException;
-import com.sammaru5.sammaru.exception.ErrorCode;
 import com.sammaru5.sammaru.repository.BoardRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,7 +10,7 @@ import java.util.List;
 
 @Transactional(readOnly = true)
 @Service @RequiredArgsConstructor
-public class BoardStatusService {
+public class BoardSearchService {
     private final BoardRepository boardRepository;
 
     public List<Board> findBoards() {

--- a/src/main/java/com/sammaru5/sammaru/web/controller/board/BoardController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/board/BoardController.java
@@ -4,7 +4,7 @@ import com.sammaru5.sammaru.domain.SearchSubject;
 import com.sammaru5.sammaru.service.article.ArticleSearchService;
 import com.sammaru5.sammaru.service.board.BoardRegisterService;
 import com.sammaru5.sammaru.service.board.BoardRemoveService;
-import com.sammaru5.sammaru.service.board.BoardStatusService;
+import com.sammaru5.sammaru.service.board.BoardSearchService;
 import com.sammaru5.sammaru.util.OverAdminRole;
 import com.sammaru5.sammaru.web.apiresult.ApiResult;
 import com.sammaru5.sammaru.web.dto.ArticleDTO;
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 public class BoardController {
 
     private final BoardRegisterService boardRegisterService;
-    private final BoardStatusService boardStatusService;
+    private final BoardSearchService boardSearchService;
     private final BoardRemoveService boardRemoveService;
     private final ArticleSearchService articleSearchService;
 
@@ -47,7 +47,7 @@ public class BoardController {
     @GetMapping("/no-permit/api/boards")
     @ApiOperation(value = "게시판 목록", notes = "게시판 목록을 조회", responseContainer = "List", response = BoardDTO.class)
     public ApiResult<List<BoardDTO>> boardList() {
-        return ApiResult.OK(boardStatusService.findBoards().stream().map(BoardDTO::new).collect(Collectors.toList()));
+        return ApiResult.OK(boardSearchService.findBoards().stream().map(BoardDTO::new).collect(Collectors.toList()));
     }
 
     @GetMapping("/no-permit/api/boards/{boardId}/pages/{pageNum}")


### PR DESCRIPTION
## 👀 이슈

resolve #128 

## 📌 개요

게시판 조회 서비스 이름 변경 

## 👩‍💻 작업 사항

- 게시판 조회 서비스 이름을 `BoardStatusService`에서 `BoardSearchService`로 변경한다.

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
