### PR TITLE
fix : 정보수정 API 에서 student_id 수정 가능하게 변경

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/domain/User.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/User.java
@@ -68,5 +68,6 @@ public class User {
         this.email = userRequest.getEmail();
         this.password = passwordEncoder.encode(userRequest.getPassword());
         this.grade = userRequest.getGrade();
+        this.studentId = userRequest.getStudentId();
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserModifyService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserModifyService.java
@@ -25,6 +25,10 @@ public class UserModifyService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, userId.toString()));
 
+        if (userRepository.existsByStudentId(userRequest.getStudentId())) {
+            throw new CustomException(ErrorCode.ALREADY_EXIST_USER, userRequest.getStudentId());
+        }
+
         if (!user.getEmail().equals(userRequest.getEmail()) && userRepository.existsByEmail(userRequest.getEmail())) {
             throw new CustomException(ErrorCode.ALREADY_EXIST_EMAIL, userRequest.getEmail());
         }

--- a/src/main/java/com/sammaru5/sammaru/web/request/UserRequest.java
+++ b/src/main/java/com/sammaru5/sammaru/web/request/UserRequest.java
@@ -3,9 +3,11 @@ package com.sammaru5.sammaru.web.request;
 import lombok.Getter;
 
 import javax.validation.constraints.Email;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
 
 @Getter
 public class UserRequest {
@@ -20,6 +22,10 @@ public class UserRequest {
     @NotBlank(message = "이메일은 필수 입력입니다")
     @Email(message = "이메일은 이메일 형식에 맞아야 됩니다")
     private String email;
+
+    @NotBlank(message = "학번은 필수 입력입니다")
+    @Size(min = 4, message = "학번은 자신의 학번 풀네임 입니다 ex) 2016XXXXXX")
+    private String studentId;
 
     @NotNull(message = "학년을 입력해주세요")
     private Integer grade;


### PR DESCRIPTION
## 👀 이슈

resolve #114 

## 📌 개요

유정보 수정 API에서 학번(student_id)도 변경 가능하게끔 수정

## 👩‍💻 작업 사항

UserRequest, modifyUserInfo 메서드에 student_id 추가

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
