### PR TITLE
refactor: 게시판 등록 서비스내의 트랜잭션 단위안에서 예외처리하도록 설정

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/service/board/BoardRegisterService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/board/BoardRegisterService.java
@@ -1,6 +1,5 @@
 package com.sammaru5.sammaru.service.board;
 
-import com.sammaru5.sammaru.domain.Board;
 import com.sammaru5.sammaru.exception.CustomException;
 import com.sammaru5.sammaru.exception.ErrorCode;
 import com.sammaru5.sammaru.web.dto.BoardDTO;
@@ -10,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 
 @Transactional
 @Service @RequiredArgsConstructor
@@ -18,11 +16,12 @@ public class BoardRegisterService {
     private final BoardRepository boardRepository;
 
     public BoardDTO addBoard(BoardRequest boardRequest) {
-        validateDuplicateBoard(boardRequest.getBoardName());
-        return BoardDTO.from(boardRepository.save(boardRequest.toEntity()));
-    }
+        String boardName = boardRequest.getBoardName();
 
-    private void validateDuplicateBoard(String boardName) {
-        if(boardRepository.existsByBoardName(boardName)) throw new CustomException(ErrorCode.ALREADY_EXIST_BOARD);
+        if(boardRepository.existsByBoardName(boardRequest.getBoardName())) {
+            throw new CustomException(ErrorCode.ALREADY_EXIST_BOARD, boardRequest.getBoardName());
+        }
+
+        return BoardDTO.from(boardRepository.save(boardRequest.toEntity()));
     }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #145

## 📌 개요

게시판 등록 서비스내의 트랜잭션 단위안에서 예외 처리하도록 설정

## 👩‍💻 작업 사항

- `validateDuplicateBoard( )` 메서드 삭제
- `addBoard( )` 메서드 내에서 게시판 중복 이름 존재 시 예외 처리하도록  설정

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
