### PR TITLE
feat: test, local 환경에서는 메모리 내장 redis를 사용하도록 개발 환경 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 
 	// https://mvnrepository.com/artifact/org.mockito/mockito-inline
 	testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.8.0'
+
+	//embedded-redis
+	implementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sammaru5/sammaru/config/EmbeddedRedisConfig.java
+++ b/src/main/java/com/sammaru5/sammaru/config/EmbeddedRedisConfig.java
@@ -17,19 +17,37 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import redis.embedded.RedisServer;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import java.time.Duration;
 
-@Profile("prod")
+@Profile("!prod")
 @Configuration
 @EnableRedisRepositories
 @EnableCaching
-public class RedisConfig {
+public class EmbeddedRedisConfig {
     @Value("${spring.redis.host}")
     private String redisHost;
 
     @Value("${spring.redis.port}")
     private int redisPort;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void redisServer() {
+        redisServer = new RedisServer(redisPort);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,6 +14,9 @@ spring:
         show_sql: true
         format_sql: true
     database: mysql
+  redis:
+    host: localhost
+    port: 6379
 
 sammaru:
   cookie:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -10,7 +10,7 @@ spring:
   cache:
     type: redis
   redis:
-    host: 172.17.0.1
+    host: localhost
     port: 6379
 
   output:


### PR DESCRIPTION
## 👀 이슈

resolve #104 

## 📌 개요

Docker없이 스프링만 로컬에서 실행시켰을 경우, 기존에는 따로 Redis 환경을 구축해줬어야 하는데,
메모리 내장 Redis를 사용하도록 구성함으로써 이러한 문제점을 해결하고, 테스트 및 개발의 편의성을 높이고자 한다.

## 👩‍💻 작업 사항

[`ozimov/embedded-redis`](https://github.com/ozimov/embedded-redis)를 사용해서 `local`, `test` profile로 spring 실행시, 메모리 내장 Redis를 사용하도록 개발 환경 구축

## ✅ 참고 사항
