### PR TITLE
fix: 관리자는 타인의 댓글을 삭제할 수 있도록 기능 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,10 +18,15 @@ repositories {
 	mavenCentral()
 }
 
+def restAssuredVersion = '5.2.0'
+
 dependencies {
 	// should be placed before JUnit dependency declaration in order to make sure that the correct version of Hamcrest is used.
-	testImplementation 'io.rest-assured:rest-assured:5.2.0'
-	testImplementation 'io.rest-assured:spring-mock-mvc:5.2.0'
+	testImplementation "io.rest-assured:rest-assured:${restAssuredVersion}"
+	testImplementation "io.rest-assured:json-path:${restAssuredVersion}"
+	testImplementation "io.rest-assured:xml-path:${restAssuredVersion}"
+	testImplementation "io.rest-assured:json-schema-validator:${restAssuredVersion}"
+	testImplementation "io.rest-assured:spring-mock-mvc:${restAssuredVersion}"
 
 	modules {
 		module("org.codehaus.groovy:groovy") {

--- a/src/main/java/com/sammaru5/sammaru/domain/Comment.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/Comment.java
@@ -2,6 +2,7 @@ package com.sammaru5.sammaru.domain;
 
 import com.sammaru5.sammaru.web.request.CommentRequest;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -44,5 +45,30 @@ public class Comment extends BaseTime {
 
     public void modifyContent(CommentRequest commentRequest) {
         this.content = commentRequest.getContent();
+    }
+
+    public boolean isIndelible(User user) {
+        // TODO 간단하게 이렇게 짜보았는데 작성자와 관리자를 분리해서 메서드가 있으면 더 좋을 것 같아요.
+        // 좋은 의견 있으면 추가해주세요.
+        return !this.getUser().equals(user) && user.getRole() != UserAuthority.ROLE_ADMIN;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (id == null) return false;
+        if (!(o instanceof Comment))
+            return false;
+
+        final Comment comment = (Comment)o;
+
+        return id.equals(comment.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        return result;
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/domain/Comment.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/Comment.java
@@ -47,10 +47,13 @@ public class Comment extends BaseTime {
         this.content = commentRequest.getContent();
     }
 
-    public boolean isIndelible(User user) {
-        // TODO 간단하게 이렇게 짜보았는데 작성자와 관리자를 분리해서 메서드가 있으면 더 좋을 것 같아요.
-        // 좋은 의견 있으면 추가해주세요.
-        return !this.getUser().equals(user) && user.getRole() != UserAuthority.ROLE_ADMIN;
+    /**
+     * 해당 Comment의 작성자인지 판별하는 메서드
+     * @param user
+     * @return
+     */
+    public boolean isWrittenBy(User user) {
+        return this.getUser().equals(user);
     }
 
     @Override

--- a/src/main/java/com/sammaru5/sammaru/domain/User.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/User.java
@@ -63,6 +63,14 @@ public class User {
         this.grade = grade;
     }
 
+    /**
+     * 해당 User의 Role이 어드민인지 판별하는 메서드
+     * @return
+     */
+    public boolean isAdmin() {
+        return this.getRole() == UserAuthority.ROLE_ADMIN;
+    }
+
     public void modifyUserInfo(UserRequest userRequest, PasswordEncoder passwordEncoder) {
         this.username = userRequest.getUsername();
         this.email = userRequest.getEmail();

--- a/src/main/java/com/sammaru5/sammaru/service/comment/CommentRemoveService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/comment/CommentRemoveService.java
@@ -27,7 +27,7 @@ public class CommentRemoveService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND, commentId.toString()));
 
-        if (comment.getUser() != user && user.getRole() != UserAuthority.ROLE_ADMIN) {
+        if (comment.isIndelible(user)) {
             throw new CustomException(ErrorCode.UNAUTHORIZED_USER_ACCESS, user.getId().toString());
         }
 

--- a/src/main/java/com/sammaru5/sammaru/service/comment/CommentRemoveService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/comment/CommentRemoveService.java
@@ -2,13 +2,12 @@ package com.sammaru5.sammaru.service.comment;
 
 import com.sammaru5.sammaru.domain.Comment;
 import com.sammaru5.sammaru.domain.User;
+import com.sammaru5.sammaru.domain.UserAuthority;
 import com.sammaru5.sammaru.exception.CustomException;
 import com.sammaru5.sammaru.exception.ErrorCode;
 import com.sammaru5.sammaru.repository.CommentRepository;
 import com.sammaru5.sammaru.repository.UserRepository;
-import com.sammaru5.sammaru.service.user.UserStatusService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,7 +27,7 @@ public class CommentRemoveService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND, commentId.toString()));
 
-        if (comment.getUser() != user) {
+        if (comment.getUser() != user && user.getRole() != UserAuthority.ROLE_ADMIN) {
             throw new CustomException(ErrorCode.UNAUTHORIZED_USER_ACCESS, user.getId().toString());
         }
 

--- a/src/main/java/com/sammaru5/sammaru/service/comment/CommentRemoveService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/comment/CommentRemoveService.java
@@ -27,7 +27,7 @@ public class CommentRemoveService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND, commentId.toString()));
 
-        if (comment.isIndelible(user)) {
+        if (!comment.isWrittenBy(user) && !user.isAdmin()) {
             throw new CustomException(ErrorCode.UNAUTHORIZED_USER_ACCESS, user.getId().toString());
         }
 

--- a/src/test/java/com/sammaru5/sammaru/WithMockCustomUser.java
+++ b/src/test/java/com/sammaru5/sammaru/WithMockCustomUser.java
@@ -2,12 +2,14 @@ package com.sammaru5.sammaru;
 
 import com.sammaru5.sammaru.domain.UserAuthority;
 import org.springframework.security.test.context.support.WithSecurityContext;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
 @WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+@DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
 public @interface WithMockCustomUser {
 
     String userId() default "1";

--- a/src/test/java/com/sammaru5/sammaru/service/article/ArticleSearchServiceTest.java
+++ b/src/test/java/com/sammaru5/sammaru/service/article/ArticleSearchServiceTest.java
@@ -84,7 +84,6 @@ class ArticleSearchServiceTest {
 
     @Test
     @DisplayName("로그인 후 게시글 정보를 가져올때 좋아요 여부가 잘 반환되는지 확인")
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
     @WithMockCustomUser(userId = "1")
     void findArticleCheckIsLikedWhenLogin() {
         // when

--- a/src/test/java/com/sammaru5/sammaru/web/controller/comment/CommentControllerTest.java
+++ b/src/test/java/com/sammaru5/sammaru/web/controller/comment/CommentControllerTest.java
@@ -1,0 +1,89 @@
+package com.sammaru5.sammaru.web.controller.comment;
+
+import com.sammaru5.sammaru.domain.*;
+import com.sammaru5.sammaru.repository.ArticleRepository;
+import com.sammaru5.sammaru.repository.BoardRepository;
+import com.sammaru5.sammaru.repository.CommentRepository;
+import com.sammaru5.sammaru.repository.UserRepository;
+import com.sammaru5.sammaru.web.request.CommentRequest;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CommentControllerTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private BoardRepository boardRepository;
+    @Autowired
+    private ArticleRepository articleRepository;
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+
+    @Mock
+    CommentRequest commentRequest = new CommentRequest();
+
+    @LocalServerPort
+    private int port;
+
+    private RequestSpecification basicRequest;
+
+    private final String adminStudentId = "admin";
+    private final String adminPassword = "password";
+
+    @BeforeEach
+    public void setUp() {
+        basicRequest = given()
+                .baseUri("http://localhost")
+                .port(port);
+        // 관리자 계정 추가
+        userRepository.save(new User(1L, adminStudentId, "admin", passwordEncoder.encode(adminPassword), "admin@naver.com", 0L, 0, 0, UserAuthority.ROLE_ADMIN));
+    }
+
+    @Test
+    @DisplayName("관리자는 다른 사용자의 댓글을 삭제할 수 있다")
+    void admin_can_delete_any_comment() {
+        User user = userRepository.save(new User(null, "202002000", "user1", "password", "email", 0L, 0, 0, UserAuthority.ROLE_MEMBER));
+        Board board = boardRepository.save(new Board(null, "board", ""));
+        Article article = articleRepository.save(new Article(null, "title", "content", 0, 0, null, board, user, null));
+        Mockito.when(commentRequest.getContent()).thenReturn("comment");
+        Comment comment = commentRepository.save(Comment.createComment(commentRequest, article, user));
+
+        String path = "/api/boards/" + board.getId() + "/articles/" + article.getId() + "/comments/" + comment.getId();
+        given().spec(basicRequest).basePath(path)
+                .header("Authorization", "Bearer " + getAdminAccessToken())
+                .when().delete()
+                .then().log().all()
+                .statusCode(200);
+        assertThat(commentRepository.findAll().isEmpty()).isTrue();
+    }
+
+    String getAdminAccessToken() {
+        Map<String, Object> jsonAsMap = new HashMap<>();
+        jsonAsMap.put("studentId", adminStudentId);
+        jsonAsMap.put("password", adminPassword);
+        return given().spec(basicRequest).contentType(ContentType.JSON).body(jsonAsMap)
+                .when().post("/auth/login")
+                .getBody().jsonPath().getJsonObject("response.accessToken").toString();
+    }
+}


### PR DESCRIPTION
## 👀 이슈

resolve #152 

## 📌 개요

관리자는 타인의 댓글을 삭제할 수 있도록 수정. 관리자용 댓글 삭제 메소드 추가

## 👩‍💻 작업 사항

- 기존 테스트 코드 리팩토링
- 관리자는 타인의 댓글을 삭제할 수 있는지 확인하는 테스트 코드 추가
- 관리자는 타인의 댓글을 삭제할 수 있도록 기존의 로직 수정

## ✅ 참고 사항
