### PR TITLE
refactor: 게시글 삭제시 하위 엔티티 동시에 제거

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/domain/Article.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/Article.java
@@ -46,6 +46,12 @@ public class Article extends BaseTime {
     @BatchSize(size = 100)
     private List<File> files = new ArrayList<>();
 
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ArticleLike> articleLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
     public static Article createArticle(ArticleRequest articleRequest, Board board, User user) {
         return Article.builder()
                 .articleRequest(articleRequest)
@@ -70,6 +76,13 @@ public class Article extends BaseTime {
         file.belongToArticle(this);
     }
 
+    public void addComment(Comment comment){
+        comments.add(comment);
+    }
+
+    public void addArticleLike(ArticleLike articleLike){
+        articleLikes.add(articleLike);
+    }
     public void removeFile() {
         files.clear();
     }

--- a/src/main/java/com/sammaru5/sammaru/domain/ArticleLike.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/ArticleLike.java
@@ -9,7 +9,6 @@ import javax.persistence.*;
 
 @Getter
 @Entity
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class ArticleLike {
@@ -31,5 +30,16 @@ public class ArticleLike {
                 .user(user)
                 .article(article)
                 .build();
+    }
+
+    @Builder
+    private ArticleLike(User user, Article article){
+        this.user = user;
+        belongToArticle(article);
+    }
+
+    private void belongToArticle(Article article){
+        this.article = article;
+        article.addArticleLike(this);
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/domain/Comment.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/Comment.java
@@ -38,11 +38,19 @@ public class Comment extends BaseTime {
     @Builder
     private Comment(CommentRequest commentRequest, User user, Article article) {
         this.content = commentRequest.getContent();
-        this.article = article;
         this.user = user;
+
+        belongToArticle(article);
     }
 
     public void modifyContent(CommentRequest commentRequest) {
         this.content = commentRequest.getContent();
     }
+
+    //==연관관계 메서드==//
+    private void belongToArticle(Article article){
+        this.article = article;
+        article.addComment(this);
+    }
+
 }

--- a/src/main/java/com/sammaru5/sammaru/service/article/ArticleRemoveService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/article/ArticleRemoveService.java
@@ -35,9 +35,6 @@ public class ArticleRemoveService {
             throw new CustomException(ErrorCode.UNAUTHORIZED_USER_ACCESS, findUser.getId().toString());
         }
 
-        articleLikeRepository.deleteAllByArticleId(articleId);
-        commentRepository.deleteAllByArticleId(articleId);
-
         articleRepository.delete(article);
         return true;
     }


### PR DESCRIPTION


## 👀 이슈

resolve #155 

## 📌 개요
 
 cascadeType지정을 통해 하위엔티티 제거

## 👩‍💻 작업 사항

 * Article에 articleLikes, comments 필드 추가
 * ArticleLike, Comment 에 연관관계 편의 메소드 추가
 * ArticleRemoveService에서 articlelike와 comment 삭제하는 로직 제거

## ✅ 참고 사항

테스트코드 사용이 아직 미숙해서 postman활용해서 테스트 했습니다.

