### PR TITLE
bug: 테스트시 redisServer 재생성으로 인한 포트충돌 문제 해결

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/config/EmbeddedRedisConfig.java
+++ b/src/main/java/com/sammaru5/sammaru/config/EmbeddedRedisConfig.java
@@ -39,7 +39,13 @@ public class EmbeddedRedisConfig {
     @PostConstruct
     public void redisServer() {
         redisServer = new RedisServer(redisPort);
-        redisServer.start();
+        // 여러 @SpringBootTest를 실행하다보면 이미 redisServer가 실행중인데, redisServer.start()를 실행하면서 포트 충돌이 발생하는 경우가 생긴다.
+        // 하지만 이때, 다른 @SpringBootTest에서 생성한 redisServer를 직접적으로 조작할 수는 없어도 통신하는 것은 가능하기 때문에 생성에 실패하더라도 테스트를 수행하는데는 문제가 없다.
+        try {
+            redisServer.start();
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+        }
     }
 
     @PreDestroy


### PR DESCRIPTION
## 👀 이슈

resolve #161 

## 📌 개요

여러 `@SpringBootTest`를 실행하다보면 이미 `redisServer`가 실행중인데, `redisServer.start()`를 실행하면서 포트 충돌이 발생하는 경우가 생긴다.

하지만 이때, 다른 `@SpringBootTest`에서 생성한 `redisServer`를 직접적으로 조작할 수는 없어도 통신하는 것은 가능하기 때문에 생성에 실패하더라도 테스트를 수행하는데는 문제가 없다.

## 👩‍💻 작업 사항

try-catch 문으로 `redisServer.start()` 부분에서 발생하는 에외 처리

## ✅ 참고 사항

https://github.com/chisan01/TIL/blob/main/project-record/sammaru-server/embedded-redis.md#embedded-redis-%ED%8F%AC%ED%8A%B8-%EC%B6%A9%EB%8F%8C-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0
