### PR TITLE
fix : 댓글목록 조회시 userId도 함께 반환

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/web/dto/CommentDTO.java
+++ b/src/main/java/com/sammaru5/sammaru/web/dto/CommentDTO.java
@@ -10,6 +10,7 @@ import java.sql.Timestamp;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentDTO {
     private Long id;
+    private Long userId;
     private String content;
     private Timestamp createDt;
     private String author;
@@ -18,6 +19,7 @@ public class CommentDTO {
         this.content = comment.getContent();
         this.createDt = comment.getCreateTime();
         this.author =comment.getUser().getUsername();
+        this.userId = comment.getUser().getId();
     }
 
     public static CommentDTO from(Comment comment){


### PR DESCRIPTION
 - CommentDTO 에 userId 필드 추가

## 👀 이슈

resolve #176 

## 📌 개요

* 댓글 목록 조회시 사용자 이름이 같으면 구분할 수 없음

## 👩‍💻 작업 사항

* 댓글 목록 조회시 userId도 함께 반환
* CommentDTO 에 userId 필드 추가


## ✅ 참고 사항

![image](https://user-images.githubusercontent.com/77261327/209803719-f07f25b2-8537-4fe0-ae46-6af47f1c2d6b.png)
