### PR TITLE
fix : 게시글 상세에 이전, 게시글 id 도 함께 제공

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/config/EmbeddedRedisConfig.java
+++ b/src/main/java/com/sammaru5/sammaru/config/EmbeddedRedisConfig.java
@@ -1,6 +1,7 @@
 package com.sammaru5.sammaru.config;
 
 import com.sammaru5.sammaru.util.ArticleCacheKeyGenerator;
+import com.sammaru5.sammaru.util.CacheKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -18,10 +19,11 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import redis.embedded.RedisServer;
-
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 @Profile("!prod")
 @Configuration
@@ -76,7 +78,16 @@ public class EmbeddedRedisConfig {
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
                 .entryTtl(Duration.ofMinutes(3L)); //캐시 유효기간 3분
 
-        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory()).cacheDefaults(redisCacheConfiguration).build();
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+
+        //article cache
+        cacheConfigurations.put(CacheKey.ARTICLE, RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofSeconds(CacheKey.ARTICLE_EXPIRE_SEC)));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory()).cacheDefaults(redisCacheConfiguration).withInitialCacheConfigurations(cacheConfigurations).build();
     }
 
     @Bean

--- a/src/main/java/com/sammaru5/sammaru/domain/Article.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/Article.java
@@ -46,12 +46,6 @@ public class Article extends BaseTime {
     @BatchSize(size = 100)
     private List<File> files = new ArrayList<>();
 
-    @Transient
-    private Article prevArticle;
-
-    @Transient
-    private Article nextArticle;
-
     public static Article createArticle(ArticleRequest articleRequest, Board board, User user) {
         return Article.builder()
                 .articleRequest(articleRequest)
@@ -86,14 +80,6 @@ public class Article extends BaseTime {
 
     public void setIsLiked(Boolean isLiked) {
         this.isLiked = isLiked;
-    }
-
-    public void setPrevArticle(Article prevArticle){
-        this.prevArticle = prevArticle;
-    }
-
-    public void setNextArticle(Article nextArticle){
-        this.nextArticle = nextArticle;
     }
 
     //== 비즈니스 메서드 ==//

--- a/src/main/java/com/sammaru5/sammaru/domain/Article.java
+++ b/src/main/java/com/sammaru5/sammaru/domain/Article.java
@@ -46,6 +46,12 @@ public class Article extends BaseTime {
     @BatchSize(size = 100)
     private List<File> files = new ArrayList<>();
 
+    @Transient
+    private Article prevArticle;
+
+    @Transient
+    private Article nextArticle;
+
     public static Article createArticle(ArticleRequest articleRequest, Board board, User user) {
         return Article.builder()
                 .articleRequest(articleRequest)
@@ -80,6 +86,14 @@ public class Article extends BaseTime {
 
     public void setIsLiked(Boolean isLiked) {
         this.isLiked = isLiked;
+    }
+
+    public void setPrevArticle(Article prevArticle){
+        this.prevArticle = prevArticle;
+    }
+
+    public void setNextArticle(Article nextArticle){
+        this.nextArticle = nextArticle;
     }
 
     //== 비즈니스 메서드 ==//

--- a/src/main/java/com/sammaru5/sammaru/repository/ArticleRepository.java
+++ b/src/main/java/com/sammaru5/sammaru/repository/ArticleRepository.java
@@ -89,4 +89,12 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             countQuery = "select count(a) from Article a where a.title like %:keyword% or a.content like %:keyword%")
     Page<Article> searchArticlesByTitleAndContent(Pageable pageable, @Param("keyword") String keyword);
 
+    // 게시판 이전글, 다음글
+
+//    select max(article_id) from article where article_id < 10 and board_id = 1;
+    @Query(value = "select max(a) from Article a where a.id < :articleId and a.board = :board")
+    Article findPrevArticle(@Param("articleId") Long articleId , @Param("board") Board board);
+
+    @Query(value = "select min(a) from Article a where a.id > :articleId and a.board = :board")
+    Article findNextArticle(@Param("articleId") Long articleId , @Param("board") Board board);
 }

--- a/src/main/java/com/sammaru5/sammaru/repository/ArticleRepository.java
+++ b/src/main/java/com/sammaru5/sammaru/repository/ArticleRepository.java
@@ -91,10 +91,9 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     // 게시판 이전글, 다음글
 
-//    select max(article_id) from article where article_id < 10 and board_id = 1;
     @Query(value = "select max(a) from Article a where a.id < :articleId and a.board = :board")
-    Article findPrevArticle(@Param("articleId") Long articleId , @Param("board") Board board);
+    Optional<Article> findPrevArticle(@Param("articleId") Long articleId , @Param("board") Board board);
 
     @Query(value = "select min(a) from Article a where a.id > :articleId and a.board = :board")
-    Article findNextArticle(@Param("articleId") Long articleId , @Param("board") Board board);
+    Optional<Article> findNextArticle(@Param("articleId") Long articleId , @Param("board") Board board);
 }

--- a/src/main/java/com/sammaru5/sammaru/repository/ArticleRepository.java
+++ b/src/main/java/com/sammaru5/sammaru/repository/ArticleRepository.java
@@ -91,9 +91,10 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     // 게시판 이전글, 다음글
 
-    @Query(value = "select max(a) from Article a where a.id < :articleId and a.board = :board")
-    Optional<Article> findPrevArticle(@Param("articleId") Long articleId , @Param("board") Board board);
+    @Query(value = "select max(a.article_id) from article a where a.article_id < :articleId and a.board_id = :boardId", nativeQuery = true)
+    Optional<Long> findPrevArticleId(@Param("articleId") Long articleId , @Param("boardId") Long boardId);
 
-    @Query(value = "select min(a) from Article a where a.id > :articleId and a.board = :board")
-    Optional<Article> findNextArticle(@Param("articleId") Long articleId , @Param("board") Board board);
+    @Query(value = "select min(a.article_id) from article a where a.article_id > :articleId and a.board_id = :boardId", nativeQuery = true)
+    Optional<Long> findNextArticleId(@Param("articleId") Long articleId , @Param("boardId") Long boardId);
+
 }

--- a/src/main/java/com/sammaru5/sammaru/service/article/ArticleRemoveService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/article/ArticleRemoveService.java
@@ -24,7 +24,7 @@ public class ArticleRemoveService {
     private final CommentRepository commentRepository;
 
     @Transactional
-    @CacheEvict(keyGenerator = "articleCacheKeyGenerator", value = "article", cacheManager = "cacheManager")
+    @CacheEvict(keyGenerator = "articleCacheKeyGenerator", value = "article", cacheManager = "cacheManager", allEntries = true)
     public boolean removeArticle(Long articleId, Long userId, Long boardId) {
         User findUser = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, userId.toString()));

--- a/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
@@ -10,6 +10,7 @@ import com.sammaru5.sammaru.repository.ArticleLikeRepository;
 import com.sammaru5.sammaru.repository.ArticleRepository;
 import com.sammaru5.sammaru.repository.BoardRepository;
 import com.sammaru5.sammaru.web.dto.ArticleDTO;
+import com.sammaru5.sammaru.web.dto.ArticleDetailDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
@@ -32,13 +33,13 @@ public class ArticleSearchService {
 
     @Transactional
     @Cacheable(keyGenerator = "articleCacheKeyGenerator", value = "article", cacheManager = "cacheManager")
-    public ArticleDTO findArticle(Long articleId) {
+    public ArticleDetailDTO findArticle(Long articleId) {
         Article article = articleRepository.findOneWithFilesAndUserById(articleId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_FOUND, articleId.toString()));
 
-        // 게시글의 이전글, 다음글 지정
-        article.setPrevArticle(articleRepository.findPrevArticle(articleId, article.getBoard()));
-        article.setNextArticle(articleRepository.findNextArticle(articleId, article.getBoard()));
+        // 게시글의 이전글, 다음글
+        Long prevArticleId = articleRepository.findPrevArticle(articleId, article.getBoard()).orElse(article).getId();
+        Long nextArticleId = articleRepository.findNextArticle(articleId, article.getBoard()).orElse(article).getId();
 
         article.plusViewCnt(); //조회수 증가
 
@@ -49,7 +50,7 @@ public class ArticleSearchService {
             article.setIsLiked(articleLikeRepository.existsByArticleIdAndUserId(articleId, currentUserId));
         } catch (CustomException e) { }
 
-        return ArticleDTO.from(article);
+        return ArticleDetailDTO.from(article, prevArticleId, nextArticleId);
     }
 
     //boardId에 해당하는 게시판의 게시글들을 paging

--- a/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
@@ -38,8 +38,8 @@ public class ArticleSearchService {
                 .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_FOUND, articleId.toString()));
 
         // 게시글의 이전글, 다음글
-        Long prevArticleId = articleRepository.findPrevArticle(articleId, article.getBoard()).orElse(article).getId();
-        Long nextArticleId = articleRepository.findNextArticle(articleId, article.getBoard()).orElse(article).getId();
+        Long prevArticleId = articleRepository.findPrevArticleId(articleId, article.getBoard().getId()).orElse(0L);
+        Long nextArticleId = articleRepository.findNextArticleId(articleId, article.getBoard().getId()).orElse(0L);
 
         article.plusViewCnt(); //조회수 증가
 

--- a/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/article/ArticleSearchService.java
@@ -36,6 +36,10 @@ public class ArticleSearchService {
         Article article = articleRepository.findOneWithFilesAndUserById(articleId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_FOUND, articleId.toString()));
 
+        // 게시글의 이전글, 다음글 지정
+        article.setPrevArticle(articleRepository.findPrevArticle(articleId, article.getBoard()));
+        article.setNextArticle(articleRepository.findNextArticle(articleId, article.getBoard()));
+
         article.plusViewCnt(); //조회수 증가
 
         article.setLikeCnt(articleLikeRepository.countAllByArticleId(articleId));

--- a/src/main/java/com/sammaru5/sammaru/util/CacheKey.java
+++ b/src/main/java/com/sammaru5/sammaru/util/CacheKey.java
@@ -5,5 +5,5 @@ public class CacheKey {
     public static final String USER = "user";
     public static final int USER_EXPIRE_SEC = 60 * 5; // 5 minutes
     public static final String ARTICLE = "article";
-    public static final int ARTICLE_EXPIRE_SEC = 60; // 1 minutes
+    public static final int ARTICLE_EXPIRE_SEC = 5; // 5 second
 }

--- a/src/main/java/com/sammaru5/sammaru/web/controller/article/ArticleController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/article/ArticleController.java
@@ -7,6 +7,7 @@ import com.sammaru5.sammaru.service.file.FileStatusService;
 import com.sammaru5.sammaru.util.OverMemberRole;
 import com.sammaru5.sammaru.web.apiresult.ApiResult;
 import com.sammaru5.sammaru.web.dto.ArticleDTO;
+import com.sammaru5.sammaru.web.dto.ArticleDetailDTO;
 import com.sammaru5.sammaru.web.request.ArticleRequest;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -43,7 +44,7 @@ public class ArticleController {
     @GetMapping("/api/boards/{boardId}/articles/{articleId}")
     @ApiOperation(value = "게시글 상세", notes = "게시글 상세 정보 가져오기")
     @OverMemberRole
-    public ApiResult<ArticleDTO> articleDetails(@PathVariable Long boardId, @PathVariable Long articleId) {
+    public ApiResult<ArticleDetailDTO> articleDetails(@PathVariable Long boardId, @PathVariable Long articleId) {
         return ApiResult.OK(articleSearchService.findArticle(articleId));
     }
 

--- a/src/main/java/com/sammaru5/sammaru/web/dto/ArticleDTO.java
+++ b/src/main/java/com/sammaru5/sammaru/web/dto/ArticleDTO.java
@@ -41,11 +41,26 @@ public class ArticleDTO {
         if (article.getFiles() != null && !article.getFiles().isEmpty()) {
             this.files = article.getFiles().stream().map(FileDTO::new).collect(Collectors.toList());
         }
-        if(article.getPrevArticle() != null){
+        if(hasPrevArticle(article)) {
             this.prevArticleId = article.getPrevArticle().getId();
         }
-        if(article.getNextArticle() != null){
+        if(hasNextArticle(article)) {
             this.nextArticleId = article.getNextArticle().getId();
         }
+    }
+
+    private Boolean hasPrevArticle(Article article) {
+
+        if(article.getPrevArticle() == null){
+            this.prevArticleId = 0L;
+            return false;
+        }else return true;
+    }
+    private Boolean hasNextArticle(Article article) {
+
+        if(article.getNextArticle() == null){
+            this.nextArticleId = 0L;
+            return false;
+        }else return true;
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/web/dto/ArticleDTO.java
+++ b/src/main/java/com/sammaru5/sammaru/web/dto/ArticleDTO.java
@@ -22,6 +22,8 @@ public class ArticleDTO {
     private Integer likeCnt;
     private Boolean isLiked;
     private List<FileDTO> files = new ArrayList<>();
+    private Long prevArticleId;
+    private Long nextArticleId;
 
     public static ArticleDTO from(Article article) {
         return new ArticleDTO(article);
@@ -38,6 +40,12 @@ public class ArticleDTO {
         this.isLiked = article.getIsLiked();
         if (article.getFiles() != null && !article.getFiles().isEmpty()) {
             this.files = article.getFiles().stream().map(FileDTO::new).collect(Collectors.toList());
+        }
+        if(article.getPrevArticle() != null){
+            this.prevArticleId = article.getPrevArticle().getId();
+        }
+        if(article.getNextArticle() != null){
+            this.nextArticleId = article.getNextArticle().getId();
         }
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/web/dto/ArticleDetailDTO.java
+++ b/src/main/java/com/sammaru5/sammaru/web/dto/ArticleDetailDTO.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ArticleDTO {
+public class ArticleDetailDTO {
     private Long id;
     private String title;
     private String content;
@@ -22,10 +22,12 @@ public class ArticleDTO {
     private Integer likeCnt;
     private Boolean isLiked;
     private List<FileDTO> files = new ArrayList<>();
+    private Long prevArticleId;
+    private Long nextArticleId;
 
-    public static ArticleDTO from(Article article) {return new ArticleDTO(article);}
+    public static ArticleDetailDTO from(Article article, Long prevArticleId, Long nextArticleId) {return new ArticleDetailDTO(article, prevArticleId, nextArticleId);}
 
-    private ArticleDTO(Article article) {
+    private ArticleDetailDTO(Article article, Long prevArticleId, Long nextArticleId) {
         this.id = article.getId();
         this.title = article.getTitle();
         this.content = article.getContent();
@@ -37,5 +39,25 @@ public class ArticleDTO {
         if (article.getFiles() != null && !article.getFiles().isEmpty()) {
             this.files = article.getFiles().stream().map(FileDTO::new).collect(Collectors.toList());
         }
+        if (prevArticleExist(prevArticleId)){
+            this.prevArticleId = prevArticleId;
+        }
+        if (nextArticleExist(nextArticleId)){
+            this.nextArticleId = nextArticleId;
+        }
+    }
+
+    private boolean prevArticleExist(Long prevArticleId){
+        if(this.id != prevArticleId)
+            return true;
+        this.prevArticleId = 0L;
+        return false;
+    }
+
+    private boolean nextArticleExist(Long nextArticleId){
+        if(this.id != nextArticleId)
+            return true;
+        this.nextArticleId = 0L;
+        return false;
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/web/dto/ArticleDetailDTO.java
+++ b/src/main/java/com/sammaru5/sammaru/web/dto/ArticleDetailDTO.java
@@ -39,25 +39,7 @@ public class ArticleDetailDTO {
         if (article.getFiles() != null && !article.getFiles().isEmpty()) {
             this.files = article.getFiles().stream().map(FileDTO::new).collect(Collectors.toList());
         }
-        if (prevArticleExist(prevArticleId)){
-            this.prevArticleId = prevArticleId;
-        }
-        if (nextArticleExist(nextArticleId)){
-            this.nextArticleId = nextArticleId;
-        }
-    }
-
-    private boolean prevArticleExist(Long prevArticleId){
-        if(this.id != prevArticleId)
-            return true;
-        this.prevArticleId = 0L;
-        return false;
-    }
-
-    private boolean nextArticleExist(Long nextArticleId){
-        if(this.id != nextArticleId)
-            return true;
-        this.nextArticleId = 0L;
-        return false;
+        this.prevArticleId = prevArticleId;
+        this.nextArticleId = nextArticleId;
     }
 }


### PR DESCRIPTION
 - ArticleRepository
   - findPrevArticle()
   - findNextArticle()
 - ArticleDetailDTO 생성
  
## 👀 이슈

resolve #179 

## 📌 개요

게시글 상세 api에 해당 게시글의 이전 게시글, 다음 게시글에 대한 정보 제공

## 👩‍💻 작업 사항

* 같은 board에 속하는 게시글에서 요청된 게시글 기준으로 최소값, 최대값을 이전글, 다음글에 매핑하여 제공
*  이전글, 다음글이 없을 경우 null


## ✅ 참고 사항
DB<br>
![image](https://user-images.githubusercontent.com/77261327/211805375-a09f3c4d-c07b-4f66-8aea-420910c29ff9.png)

이전글이 존재하지 않는 경우 <br>
![image](https://user-images.githubusercontent.com/77261327/214577822-9487035a-e870-42f6-84b5-90b58e5e40e0.png)

다음글이 존재하지 않는 경우 <br>
![image](https://user-images.githubusercontent.com/77261327/214577895-47c13c51-a00d-4bd7-9357-1dcd2ffd4c91.png)

같은 board에 속하는 다음글 이전글 제공
![image](https://user-images.githubusercontent.com/77261327/211805659-061640a6-01ee-49cb-8240-cc9893bce0c0.png)

