### PR TITLE
refactor: login, reissue, logout 로직 변경 (#185)

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sammaru5/sammaru/config/jwt/JwtAuthenticationFilter.java
@@ -8,7 +8,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -28,8 +27,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String jwt = resolveToken(request);
 
         // 2. Token의 유효성을 검사하고 정상 토큰이라면 Authentication을 SecurityContext에 저장합니다.
-        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
-            Authentication authentication = tokenProvider.getAuthentication(jwt);
+        if (StringUtils.hasText(jwt) && tokenProvider.validateAccessToken(jwt)) {
+            Authentication authentication = tokenProvider.getAuthentication(jwt, true);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/src/main/java/com/sammaru5/sammaru/config/jwt/JwtToken.java
+++ b/src/main/java/com/sammaru5/sammaru/config/jwt/JwtToken.java
@@ -1,6 +1,6 @@
 package com.sammaru5.sammaru.config.jwt;
 
-import com.sammaru5.sammaru.web.dto.JwtDTO;
+import com.sammaru5.sammaru.web.dto.JwtDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,12 +18,19 @@ public class JwtToken {
     private String accessToken;
     private String refreshToken;
     private Date accessTokenExpiresTime;
+    private long refreshTokenExpiresTime;
 
-    public JwtDTO toDto() {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        return JwtDTO.builder()
+    public static JwtToken ofTokens(String accessToken, String refreshToken) {
+        return JwtToken.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .build();
+    }
+
+    public JwtDto toDto() {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        return JwtDto.builder()
+                .accessToken(accessToken)
                 .accessTokenExpiresTime(sdf.format(accessTokenExpiresTime))
                 .build();
     }

--- a/src/main/java/com/sammaru5/sammaru/config/jwt/TokenProvider.java
+++ b/src/main/java/com/sammaru5/sammaru/config/jwt/TokenProvider.java
@@ -79,21 +79,21 @@ public class TokenProvider {
                 .grantType(BEARER_TYPE)
                 .accessToken(accessToken)
                 .accessTokenExpiresTime(accessTokenExpiresAt)
+                .refreshTokenExpiresTime(REFRESH_TOKEN_EXPIRE_TIME)
                 .refreshToken(refreshToken)
                 .build();
     }
 
-    public Authentication getAuthentication(String accessToken) {
+    public Authentication getAuthentication(String accessToken, boolean isNotExpired) {
         // 1. Access Token 을 복호화합니다.
         Claims claims = parseClaims(accessToken);
 
-        // 만료된 accessToken 일 때
-        if (claims.getExpiration().before(new Date())) {
+        if (isNotExpired && claims.getExpiration().before(new Date())) {
             throw new CustomException(ErrorCode.EXPIRED_TOKEN);
         }
 
         // 권한 정보가 없는 토큰일 때
-        if (claims.get(AUTHORITIES_KEY) == null) {
+        if (null == claims.get(AUTHORITIES_KEY)) {
             throw new CustomException(ErrorCode.TOKEN_WITHOUT_AUTHORITY);
         }
 
@@ -119,6 +119,20 @@ public class TokenProvider {
             log.info("잘못된 JWT 서명입니다.");
         } catch (ExpiredJwtException e) {
             log.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원하지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+
+    public boolean validateAccessToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.");
         } catch (UnsupportedJwtException e) {
             log.info("지원하지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
+++ b/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED_USER_ACCESS(HttpStatus.UNAUTHORIZED, "권한이 없는 사용자의 접근입니다!"),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 유효하지 않습니다!"),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레쉬 토큰이 유효하지 않습니다!"),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     TOKEN_WITHOUT_AUTHORITY(HttpStatus.UNAUTHORIZED, "권한이 없는 토큰입니다."),

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserLoginService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserLoginService.java
@@ -3,7 +3,6 @@ package com.sammaru5.sammaru.service.user;
 import com.sammaru5.sammaru.config.jwt.JwtToken;
 import com.sammaru5.sammaru.config.jwt.TokenProvider;
 import com.sammaru5.sammaru.util.redis.RedisUtil;
-import com.sammaru5.sammaru.web.dto.JwtDTO;
 import com.sammaru5.sammaru.web.request.SignInRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,18 +25,14 @@ public class UserLoginService {
     private long REFRESH_TOKEN_EXPIRE_TIME;
 
     @Transactional
-    public JwtDTO login(SignInRequest signInRequest) {
-
+    public JwtToken login(SignInRequest signInRequest) {
         UsernamePasswordAuthenticationToken authenticationToken = signInRequest.toAuthentication();
-
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-
-        JwtToken tokenDto = tokenProvider.generateTokenDto(authentication);
+        JwtToken jwtToken = tokenProvider.generateTokenDto(authentication);
 
         redisUtil.deleteData("RT:" + authentication.getName());
+        redisUtil.setDataExpire("RT:" + authentication.getName(), jwtToken.getRefreshToken(), REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.MILLISECONDS);
 
-        redisUtil.setDataExpire("RT:" + authentication.getName(), tokenDto.getRefreshToken(), REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.MILLISECONDS);
-
-        return tokenDto.toDto();
+        return jwtToken;
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/web/controller/auth/AuthController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/auth/AuthController.java
@@ -1,9 +1,10 @@
 package com.sammaru5.sammaru.web.controller.auth;
 
+import com.sammaru5.sammaru.config.jwt.JwtToken;
 import com.sammaru5.sammaru.config.security.SecurityUtil;
 import com.sammaru5.sammaru.service.user.*;
 import com.sammaru5.sammaru.web.apiresult.ApiResult;
-import com.sammaru5.sammaru.web.dto.JwtDTO;
+import com.sammaru5.sammaru.web.dto.JwtDto;
 import com.sammaru5.sammaru.web.dto.UserDTO;
 import com.sammaru5.sammaru.web.request.SignInRequest;
 import com.sammaru5.sammaru.web.request.SignUpRequest;
@@ -11,9 +12,14 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.time.Duration;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,6 +35,9 @@ public class AuthController {
     @Value("${sammaru.cookie.domain}")
     private String cookieDomain;
 
+    @Value("${sammaru.cookie.secure}")
+    private boolean cookieSecure;
+
     @PostMapping("/auth/signup")
     @ApiOperation(value = "회원가입", notes = "사용자 회원가입", response = UserDTO.class)
     public ApiResult<?> userSignUp(@Valid @RequestBody SignUpRequest signUpRequest) {
@@ -36,15 +45,25 @@ public class AuthController {
     }
 
     @PostMapping("/auth/login")
-    @ApiOperation(value = "로그인", notes = "엑세스 토큰과 리프레쉬 토큰 발급", response = JwtDTO.class)
-    public ApiResult<?> userSignIn(@Valid @RequestBody SignInRequest signInRequest) {
-        return ApiResult.OK(userLoginService.login(signInRequest));
+    @ApiOperation(value = "로그인", notes = "엑세스 토큰과 리프레쉬 토큰 발급", response = JwtDto.class)
+    public ResponseEntity<?> userSignIn(@Valid @RequestBody SignInRequest signInRequest) {
+        JwtToken jwtToken = userLoginService.login(signInRequest);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, createRefreshTokenCookie(jwtToken).toString())
+                .body(ApiResult.OK(jwtToken.toDto()));
     }
 
     @PostMapping("/auth/reissue")
-    @ApiOperation(value = "엑세스 토큰 재발급", notes = "만료된 엑세스 토큰과, 리프레쉬 토큰을 이용해 토큰 재 발급", response = JwtDTO.class)
-    public ApiResult<?> userReissue(@Valid @RequestBody TokenRequest tokenRequest) {
-        return ApiResult.OK(userReissueService.reissue(tokenRequest));
+    @ApiOperation(value = "엑세스 토큰 재발급", notes = "만료된 엑세스 토큰과, 리프레쉬 토큰을 이용해 토큰 재 발급", response = JwtDto.class)
+    public ResponseEntity<?> userReissue(@Valid @RequestBody TokenRequest tokenRequest,
+                                         @CookieValue(name = "samrft") String refreshToken) {
+        JwtToken jwtTokenRequest = JwtToken.ofTokens(tokenRequest.getAccessToken(), refreshToken);
+        JwtToken jwtTokenResponse = userReissueService.reissue(jwtTokenRequest);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, createRefreshTokenCookie(jwtTokenResponse).toString())
+                .body(ApiResult.OK(jwtTokenResponse.toDto()));
     }
 
     @PostMapping("/auth/tempPassword")
@@ -55,8 +74,32 @@ public class AuthController {
 
     @DeleteMapping("/auth/logout")
     @ApiOperation(value = "로그아웃", notes = "Refresh Token 삭제")
-    public ApiResult<Boolean> logout() {
-        return ApiResult.OK(userLogoutService.deleteRefreshToken(SecurityUtil.getCurrentUserId()));
+    public ResponseEntity<?> logout() {
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, removeRefreshTokenCookie().toString())
+                .body(ApiResult.OK(userLogoutService.deleteRefreshToken(SecurityUtil.getCurrentUserId())));
+    }
+
+    private ResponseCookie createRefreshTokenCookie(JwtToken jwtToken) {
+        return ResponseCookie.from("samrft", jwtToken.getRefreshToken())
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/auth/reissue")
+                .maxAge(Duration.ofMillis(jwtToken.getRefreshTokenExpiresTime()))
+                .sameSite("Strict")
+                .domain(cookieDomain)
+                .build();
+    }
+
+    private ResponseCookie removeRefreshTokenCookie() {
+        return ResponseCookie.from("samrft", "")
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/auth/reissue")
+                .maxAge(0)
+                .sameSite("Strict")
+                .domain(cookieDomain)
+                .build();
     }
 
 }

--- a/src/main/java/com/sammaru5/sammaru/web/controller/auth/TokenRequest.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/auth/TokenRequest.java
@@ -5,5 +5,4 @@ import lombok.Data;
 @Data
 public class TokenRequest {
     private String accessToken;
-    private String refreshToken;
 }

--- a/src/main/java/com/sammaru5/sammaru/web/dto/JwtDto.java
+++ b/src/main/java/com/sammaru5/sammaru/web/dto/JwtDto.java
@@ -5,9 +5,8 @@ import lombok.Data;
 
 @Builder
 @Data
-public class JwtDTO {
+public class JwtDto {
     private final String tokenType = "Bearer";
     private String accessToken;
-    private String refreshToken;
     private String accessTokenExpiresTime;
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,8 +3,8 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     # 로컬 테스트용 DB
     url: jdbc:mysql://localhost:3306/sammaru?serverTimezone=UTC&characterEncoding=UTF-8
-    username: sammaru
-    password: sammaru
+    username: root
+    password: root1234
 
   jpa:
     hibernate:
@@ -21,4 +21,5 @@ spring:
 sammaru:
   cookie:
     domain: localhost
+    secure: false
   fileDir: src/main/resources/files/

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,8 +3,8 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     # 로컬 테스트용 DB
     url: jdbc:mysql://localhost:3306/sammaru?serverTimezone=UTC&characterEncoding=UTF-8
-    username: root
-    password: root1234
+    username: sammaru
+    password: sammaru
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 👀 이슈

resolve #185 

## 📌 개요

login, reissue, logout 로직 변경

## 👩‍💻 작업 사항

login, reissue, logout 로직 변경
- 기존 access token, refresh token 두 개를 body로 실어보내는 로직에서 access token만 body로 보내고 refresh token은 httponly, secure, samesite 옵션을 가진 cookie로 담아 보내도록 수정했습니다.

## ✅ 참고 사항

application-local.yml에는 `sammaru.cookie.secure` 값이 **_false_** 로 설정되어있는데
application-prod.yml에도 `sammaru.cookie.secure` 를 추가해주시고 값을 **_true_** 설정해주세요(아래 사진 참고)
![image](https://user-images.githubusercontent.com/66486860/218294538-82e2027f-dc86-48d6-8748-84a25d8f2eac.png)
