### PR TITLE
fix: 기존 회원 정보 api deprecate, 관리자용 회원정보 수정 api 추가

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/service/user/UserModifyService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserModifyService.java
@@ -7,6 +7,7 @@ import com.sammaru5.sammaru.exception.ErrorCode;
 import com.sammaru5.sammaru.repository.UserRepository;
 import com.sammaru5.sammaru.web.dto.UserDTO;
 import com.sammaru5.sammaru.web.request.PointRequest;
+import com.sammaru5.sammaru.web.request.UserInfoModifyRequestDto;
 import com.sammaru5.sammaru.web.request.UserModifyRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -22,6 +23,19 @@ public class UserModifyService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public UserDTO modifyUserV2(UserInfoModifyRequestDto requestDto) {
+        User user = userRepository.findById(requestDto.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, requestDto.getUserId().toString()));
+
+        user.modifyStudentId(requestDto.getStudentId());
+        user.modifyUsername(requestDto.getUsername());
+        user.modifyEmail(requestDto.getEmail());
+        user.setGeneration(requestDto.getGeneration());
+
+        return UserDTO.from(user);
+    }
 
     @Transactional
     public UserDTO modifyUser(Long userId, UserModifyRequestDto requestDto) {

--- a/src/main/java/com/sammaru5/sammaru/web/controller/user/UserController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/user/UserController.java
@@ -9,10 +9,7 @@ import com.sammaru5.sammaru.util.OverAdminRole;
 import com.sammaru5.sammaru.util.OverMemberRole;
 import com.sammaru5.sammaru.web.apiresult.ApiResult;
 import com.sammaru5.sammaru.web.dto.UserDTO;
-import com.sammaru5.sammaru.web.request.GenerationRequest;
-import com.sammaru5.sammaru.web.request.PointRequest;
-import com.sammaru5.sammaru.web.request.RoleRequest;
-import com.sammaru5.sammaru.web.request.UserModifyRequestDto;
+import com.sammaru5.sammaru.web.request.*;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -79,11 +76,18 @@ public class UserController {
         return ApiResult.OK(userSearchService.findUsersByRole(role));
     }
 
-    @ApiOperation(value = "회원 정보 수정", notes = "회원 정보 수정하기")
+    //deprecated
     @OverAdminRole
     @PatchMapping("/api/user/info")
     public ApiResult<UserDTO> userModify(@RequestBody UserModifyRequestDto requestDto) {
         return ApiResult.OK(userModifyService.modifyUser(SecurityUtil.getCurrentUserId(), requestDto));
+    }
+
+    @ApiOperation(value = "회원 정보 수정 v2", notes = "studentId, username, email, generation 회원 정보 수정하기")
+    @OverAdminRole
+    @PatchMapping("/api/v2/user/info")
+    public ApiResult<UserDTO> userModifyV2(@NotBlank @RequestBody UserInfoModifyRequestDto requestDto) {
+        return ApiResult.OK(userModifyService.modifyUserV2(requestDto));
     }
 
     @ApiOperation(value = "비밀번호 변경", notes = "비밀번호 변경하기")

--- a/src/main/java/com/sammaru5/sammaru/web/request/UserInfoModifyRequestDto.java
+++ b/src/main/java/com/sammaru5/sammaru/web/request/UserInfoModifyRequestDto.java
@@ -1,0 +1,20 @@
+package com.sammaru5.sammaru.web.request;
+
+import lombok.Getter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class UserInfoModifyRequestDto {
+    @NotNull(message = "userId는 필수입니다.")
+    private Long userId;
+    @NotNull(message = "학번을 입력해주세요.")
+    private String studentId;
+    @NotNull(message = "이름을 입력해주세요.")
+    private String username;
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+    @NotNull(message = "기수를 입력해주세요.")
+    private Integer generation;
+}


### PR DESCRIPTION
## 👀 이슈

resolve #188 

## 📌 개요

기존 회원 정보 api deprecate, 관리자용 회원정보 수정 api 추가

## 👩‍💻 작업 사항

기존 회원 정보 api deprecate, 관리자용 회원정보 수정 api 추가

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
