### PR TITLE
fix: 회원가입시 이메일에 대한 인증 기능 추가

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/config/WebSecurityConfig.java
+++ b/src/main/java/com/sammaru5/sammaru/config/WebSecurityConfig.java
@@ -84,7 +84,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/auth/login").permitAll()
                 .antMatchers("/auth/reissue").permitAll()
                 .antMatchers("/auth/tempPassword").permitAll()
-                .antMatchers("/auth/tempPassword").permitAll()
                 .antMatchers("/auth/send").permitAll()
                 .antMatchers("/auth/verify").permitAll()
                 .antMatchers("/no-permit/**").permitAll()

--- a/src/main/java/com/sammaru5/sammaru/config/WebSecurityConfig.java
+++ b/src/main/java/com/sammaru5/sammaru/config/WebSecurityConfig.java
@@ -84,6 +84,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/auth/login").permitAll()
                 .antMatchers("/auth/reissue").permitAll()
                 .antMatchers("/auth/tempPassword").permitAll()
+                .antMatchers("/auth/tempPassword").permitAll()
+                .antMatchers("/auth/send").permitAll()
+                .antMatchers("/auth/verify").permitAll()
                 .antMatchers("/no-permit/**").permitAll()
                 .anyRequest().authenticated();
 

--- a/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
+++ b/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레쉬 토큰이 유효하지 않습니다!"),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     TOKEN_WITHOUT_AUTHORITY(HttpStatus.UNAUTHORIZED, "권한이 없는 토큰입니다."),
+    INVALID_EMAIL(HttpStatus.UNAUTHORIZED, "인증되지 않은 이메일입니다. "),
 
     // 403 FORBIDDEN
     USER_POINT_CANT_NEGATIVE(HttpStatus.FORBIDDEN, "사용자의 포인트는 음수가 될 수 없습니다!"),
@@ -35,7 +36,7 @@ public enum ErrorCode {
 
     // 404 NOT FOUND
     ARTICLE_NOT_LIKED(HttpStatus.NOT_FOUND, "좋아요를 누르지 않은 게시글입니다"),
-    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "유효하지 않는 인증코드 입니다."),
+    INVALID_VERIFICATION_CODE(HttpStatus.NOT_FOUND, "유효하지 않는 인증코드 입니다."),
 
     // 406 NOT ACCEPTABLE
     ACCESS_DENIED(HttpStatus.NOT_ACCEPTABLE, "접근이 거부되었습니다!"),

--- a/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
+++ b/src/main/java/com/sammaru5/sammaru/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
 
     // 404 NOT FOUND
     ARTICLE_NOT_LIKED(HttpStatus.NOT_FOUND, "좋아요를 누르지 않은 게시글입니다"),
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "유효하지 않는 인증코드 입니다."),
 
     // 406 NOT ACCEPTABLE
     ACCESS_DENIED(HttpStatus.NOT_ACCEPTABLE, "접근이 거부되었습니다!"),

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
@@ -3,6 +3,7 @@ package com.sammaru5.sammaru.service.user;
 
 import com.sammaru5.sammaru.exception.CustomException;
 import com.sammaru5.sammaru.exception.ErrorCode;
+import com.sammaru5.sammaru.repository.UserRepository;
 import com.sammaru5.sammaru.util.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 import javax.mail.Message;
 import javax.mail.internet.MimeMessage;
 import java.util.Random;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,7 +20,13 @@ public class UserEmailVerifyService {
     private final JavaMailSender javaMailSender;
     private final RedisUtil redisUtil;
 
+    private final UserRepository userRepository;
+
     public Boolean sendVerificationCode(String userEmail) {
+
+        if(existEmail(userEmail)){
+            throw new CustomException(ErrorCode.ALREADY_EXIST_EMAIL, userEmail);
+        }
 
         String verificationCode = getVerificationCode();
 
@@ -77,6 +85,11 @@ public class UserEmailVerifyService {
     }
     private void deleteVerificationCode(String verificationCode) {
         redisUtil.deleteData(verificationCode);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existEmail(String userEmail){
+        return userRepository.existsByEmail(userEmail);
     }
 }
 

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
@@ -5,9 +5,10 @@ import com.sammaru5.sammaru.exception.CustomException;
 import com.sammaru5.sammaru.exception.ErrorCode;
 import com.sammaru5.sammaru.util.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+import javax.mail.Message;
+import javax.mail.internet.MimeMessage;
 import java.util.Random;
 
 @Service
@@ -49,12 +50,22 @@ public class UserEmailVerifyService {
     }
 
     private void sendMail(String userEmail, String verificationCode) {
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(userEmail);
-        message.setSubject("인증 코드");
-        message.setText(verificationCode);
-
-        javaMailSender.send(message);
+        MimeMessage message = javaMailSender.createMimeMessage();
+        try {
+            message.addRecipients(Message.RecipientType.TO, userEmail);
+            message.setSubject("SAMMaru 인증 코드");
+            String htmlStr =
+                    "<div>" +
+                    "  <h3>SAMMaru</h3>\n" +
+                    "  <div><p>다음 인증코드를 입력해주세요.</p><p>인증코드: <span style=\"color:blue\">"
+                    + verificationCode +
+                    "</span></p></div>" +
+                    "</div>";
+            message.setText(htmlStr,"UTF-8", "html");
+            javaMailSender.send(message);
+        } catch (Exception e ){
+            e.printStackTrace();
+        }
     }
 
     private boolean validateVerificationCode(String verificationCode) {

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
@@ -4,6 +4,7 @@ package com.sammaru5.sammaru.service.user;
 import com.sammaru5.sammaru.exception.CustomException;
 import com.sammaru5.sammaru.exception.ErrorCode;
 import com.sammaru5.sammaru.repository.UserRepository;
+import com.sammaru5.sammaru.util.CacheKey;
 import com.sammaru5.sammaru.util.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -19,7 +20,6 @@ public class UserEmailVerifyService {
 
     private final JavaMailSender javaMailSender;
     private final RedisUtil redisUtil;
-
     private final UserRepository userRepository;
 
     public Boolean sendVerificationCode(String userEmail) {
@@ -81,7 +81,7 @@ public class UserEmailVerifyService {
     }
 
     private void saveVerificationCode(String verificationCode, String userEmail) {
-        redisUtil.setDataExpire(verificationCode, userEmail, 300);
+        redisUtil.setDataExpire(verificationCode, userEmail, CacheKey.VERIFICATION_CODE_EXPIRE_SEC);
     }
 
     @Transactional(readOnly = true)
@@ -95,7 +95,7 @@ public class UserEmailVerifyService {
 
     private void saveTempVerifiedEmail(String verificationCode){
         String authenticatedEmail = redisUtil.getData(verificationCode);
-        redisUtil.setDataExpire(authenticatedEmail, verificationCode, 300);
+        redisUtil.setDataExpire(authenticatedEmail, verificationCode, CacheKey.TEMP_EMAIL_EXPIRE_SEC);
     }
 }
 

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
@@ -1,0 +1,71 @@
+package com.sammaru5.sammaru.service.user;
+
+
+import com.sammaru5.sammaru.exception.CustomException;
+import com.sammaru5.sammaru.exception.ErrorCode;
+import com.sammaru5.sammaru.util.redis.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class UserEmailVerifyService {
+
+    private final JavaMailSender javaMailSender;
+    private final RedisUtil redisUtil;
+
+    public Boolean sendVerificationCode(String userEmail) {
+
+        String verificationCode = getVerificationCode();
+
+        saveVerificationCode(userEmail, verificationCode);
+
+        sendMail(userEmail, verificationCode);
+
+        return true;
+    }
+
+    public Boolean verifyEmail(String verificationCode) {
+        if (!validateVerificationCode(verificationCode)){
+            throw new CustomException(ErrorCode.INVALID_VERIFICATION_CODE);
+        }
+        deleteVerificationCode(verificationCode);
+        return true;
+    }
+
+    private String getVerificationCode(){
+        Random random = new Random();
+
+        StringBuilder code = new StringBuilder();
+        for (int j = 0; j < 6; j++) {
+            int randomInt = random.nextInt(36);
+            char c = (randomInt < 10) ? (char)('0' + randomInt) : (char)('A' + randomInt - 10);
+            code.append(c);
+        }
+        return code.toString();
+    }
+
+    private void sendMail(String userEmail, String verificationCode) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(userEmail);
+        message.setSubject("인증 코드");
+        message.setText(verificationCode);
+
+        javaMailSender.send(message);
+    }
+
+    private boolean validateVerificationCode(String verificationCode) {
+        return redisUtil.hasKey(verificationCode);
+    }
+
+    private void saveVerificationCode(String userEmail, String verificationCode) {
+        redisUtil.setDataExpire(verificationCode, userEmail, 300);
+    }
+    private void deleteVerificationCode(String verificationCode) {
+        redisUtil.deleteData(verificationCode);
+    }
+}
+

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
@@ -24,7 +24,7 @@ public class UserEmailVerifyService {
 
     public Boolean sendVerificationCode(String userEmail) {
 
-        if(isNotProperEmail(userEmail)){
+        if( isNotProperEmail(userEmail)){
             throw new CustomException(ErrorCode.VALID_CHECK_FAIL, userEmail);
         }
 
@@ -93,7 +93,7 @@ public class UserEmailVerifyService {
             throw new CustomException(ErrorCode.ALREADY_EXIST_EMAIL, userEmail);
         }
         return userEmail == null ||
-                !userEmail.contains("@");
+                !(userEmail.contains("@gmail.com") || userEmail.contains("@naver.com"));
     }
 
     private void saveTempVerifiedEmail(String verificationCode){

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
@@ -24,8 +24,8 @@ public class UserEmailVerifyService {
 
     public Boolean sendVerificationCode(String userEmail) {
 
-        if(existEmail(userEmail)){
-            throw new CustomException(ErrorCode.ALREADY_EXIST_EMAIL, userEmail);
+        if(isNotProperEmail(userEmail)){
+            throw new CustomException(ErrorCode.VALID_CHECK_FAIL, userEmail);
         }
 
         String verificationCode = getVerificationCode();
@@ -85,8 +85,12 @@ public class UserEmailVerifyService {
     }
 
     @Transactional(readOnly = true)
-    public boolean existEmail(String userEmail){
-        return userRepository.existsByEmail(userEmail);
+    public boolean isNotProperEmail(String userEmail){
+        if(userRepository.existsByEmail(userEmail)){
+            throw new CustomException(ErrorCode.ALREADY_EXIST_EMAIL, userEmail);
+        }
+        return userEmail == null ||
+                !userEmail.contains("@");
     }
 
     private void saveTempVerifiedEmail(String verificationCode){

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserRegisterService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserRegisterService.java
@@ -41,11 +41,11 @@ public class UserRegisterService {
     }
     private boolean isValidEmail(String userEmail){
 
-        if (!redisUtil.hasKey(userEmail)){
+        if (!redisUtil.hasKey(userEmail+":auth")){
             return false;
         }
-        redisUtil.deleteData(redisUtil.getData(userEmail));
-        redisUtil.deleteData(userEmail);
+        redisUtil.deleteData(redisUtil.getData(userEmail+":auth"));
+        redisUtil.deleteData(userEmail+":auth");
         return true;
     }
 }

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserRegisterService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserRegisterService.java
@@ -32,14 +32,14 @@ public class UserRegisterService {
             throw new CustomException(ErrorCode.ALREADY_EXIST_EMAIL, signUpRequest.getEmail());
         }
 
-        if (!checkEmailValidity(signUpRequest.getEmail())){
+        if (!isValidEmail(signUpRequest.getEmail())){
             throw new CustomException(ErrorCode.INVALID_EMAIL, signUpRequest.getEmail());
         }
 
         User user = signUpRequest.toEntityWithEncryptingPassword(passwordEncoder);
         return UserDTO.from(userRepository.save(user));
     }
-    private boolean checkEmailValidity(String userEmail){
+    private boolean isValidEmail(String userEmail){
 
         if (!redisUtil.hasKey(userEmail)){
             return false;

--- a/src/main/java/com/sammaru5/sammaru/util/CacheKey.java
+++ b/src/main/java/com/sammaru5/sammaru/util/CacheKey.java
@@ -4,6 +4,9 @@ public class CacheKey {
     public static final int DEFAULT_EXPIRE_SEC = 60; // 1 minutes
     public static final String USER = "user";
     public static final int USER_EXPIRE_SEC = 60 * 5; // 5 minutes
+    public static final int VERIFICATION_CODE_EXPIRE_SEC = 60 * 5; // 5 minutes
+    public static final int TEMP_EMAIL_EXPIRE_SEC = 60 * 5; // 5 minutes
+
     public static final String ARTICLE = "article";
     public static final int ARTICLE_EXPIRE_SEC = 5; // 5 second
 }

--- a/src/main/java/com/sammaru5/sammaru/util/redis/RedisUtil.java
+++ b/src/main/java/com/sammaru5/sammaru/util/redis/RedisUtil.java
@@ -38,4 +38,8 @@ public class RedisUtil {
     public void deleteData(String key) {
         redisTemplate.delete(key);
     }
+
+    public boolean hasKey(String key) {
+        return redisTemplate.hasKey(key);
+    }
 }

--- a/src/main/java/com/sammaru5/sammaru/web/controller/auth/AuthController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/auth/AuthController.java
@@ -8,6 +8,7 @@ import com.sammaru5.sammaru.web.dto.JwtDto;
 import com.sammaru5.sammaru.web.dto.UserDTO;
 import com.sammaru5.sammaru.web.request.SignInRequest;
 import com.sammaru5.sammaru.web.request.SignUpRequest;
+import com.sammaru5.sammaru.web.request.VerificationCodeRequest;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -89,8 +90,8 @@ public class AuthController {
 
     @PostMapping("/auth/verify")
     @ApiOperation(value = "이메일 검증", notes = "인증 코드 확인을 통한 이메일 검증")
-    public ApiResult<Boolean> verifyEmail(@RequestParam String code) {
-        return ApiResult.OK(userEmailVerifyService.verifyEmail(code));
+    public ApiResult<Boolean> verifyEmail(@Valid @RequestBody VerificationCodeRequest verificationCodeRequest) {
+        return ApiResult.OK(userEmailVerifyService.verifyEmail(verificationCodeRequest.getVerificationCode()));
     }
 
     private ResponseCookie createRefreshTokenCookie(JwtToken jwtToken) {

--- a/src/main/java/com/sammaru5/sammaru/web/controller/auth/AuthController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/auth/AuthController.java
@@ -31,6 +31,7 @@ public class AuthController {
     private final UserReissueService userReissueService;
     private final UserTempPasswordService userTempPasswordService;
     private final UserLogoutService userLogoutService;
+    private final UserEmailVerifyService userEmailVerifyService;
 
     @Value("${sammaru.cookie.domain}")
     private String cookieDomain;
@@ -78,6 +79,18 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.OK)
                 .header(HttpHeaders.SET_COOKIE, removeRefreshTokenCookie().toString())
                 .body(ApiResult.OK(userLogoutService.deleteRefreshToken(SecurityUtil.getCurrentUserId())));
+    }
+
+    @PostMapping("/auth/send")
+    @ApiOperation(value = "인증 코드 발송", notes = "작성한 이메일로 인증코드 발송")
+    public ApiResult<Boolean> sendVerificationCode(@RequestParam String userEmail) {
+        return ApiResult.OK(userEmailVerifyService.sendVerificationCode(userEmail));
+    }
+
+    @PostMapping("/auth/verify")
+    @ApiOperation(value = "이메일 검증", notes = "인증 코드 확인을 통한 이메일 검증")
+    public ApiResult<Boolean> verifyEmail(@RequestParam String verificationCode) {
+        return ApiResult.OK(userEmailVerifyService.verifyEmail(verificationCode));
     }
 
     private ResponseCookie createRefreshTokenCookie(JwtToken jwtToken) {

--- a/src/main/java/com/sammaru5/sammaru/web/controller/auth/AuthController.java
+++ b/src/main/java/com/sammaru5/sammaru/web/controller/auth/AuthController.java
@@ -89,8 +89,8 @@ public class AuthController {
 
     @PostMapping("/auth/verify")
     @ApiOperation(value = "이메일 검증", notes = "인증 코드 확인을 통한 이메일 검증")
-    public ApiResult<Boolean> verifyEmail(@RequestParam String verificationCode) {
-        return ApiResult.OK(userEmailVerifyService.verifyEmail(verificationCode));
+    public ApiResult<Boolean> verifyEmail(@RequestParam String code) {
+        return ApiResult.OK(userEmailVerifyService.verifyEmail(code));
     }
 
     private ResponseCookie createRefreshTokenCookie(JwtToken jwtToken) {

--- a/src/main/java/com/sammaru5/sammaru/web/request/VerificationCodeRequest.java
+++ b/src/main/java/com/sammaru5/sammaru/web/request/VerificationCodeRequest.java
@@ -1,0 +1,13 @@
+package com.sammaru5.sammaru.web.request;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class VerificationCodeRequest {
+
+    @NotBlank(message = "인증번호는 필수 입력입니다.")
+    private String verificationCode;
+
+}


### PR DESCRIPTION
## 👀 이슈

resolve #189 

## 📌 개요

올바르지 않은 이메일로 가입한 사례 존재함
회원가입시 이메일에 대한 인증 기능 추가

## 👩‍💻 작업 사항

 - /auth/send 
     - 해당 email로 인증코드 전송
 - /auth/verify
     - 인증코드를 통한 이메일 검증
 - 회원가입시 인증받은 이메일인지 검증하는 로직 추가
 
인증코드, 인증된 이메일 저장은 redis를 활용했습니다.

## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->

![image](https://user-images.githubusercontent.com/77261327/224738483-1bfe0eac-e71d-4f42-bc8d-95dd372128f6.png)

