### PR TITLE
fix : 인증코드 유효 이슈 해결

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
@@ -99,6 +99,7 @@ public class UserEmailVerifyService {
     private void saveTempVerifiedEmail(String verificationCode){
         String userEmail = redisUtil.getData(verificationCode);
         redisUtil.deleteData(userEmail);
+        redisUtil.deleteData(verificationCode);
         redisUtil.setDataExpire(userEmail+":auth", verificationCode, CacheKey.TEMP_EMAIL_EXPIRE_SEC);
     }
 

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserRegisterService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserRegisterService.java
@@ -44,7 +44,6 @@ public class UserRegisterService {
         if (!redisUtil.hasKey(userEmail+":auth")){
             return false;
         }
-        redisUtil.deleteData(redisUtil.getData(userEmail+":auth"));
         redisUtil.deleteData(userEmail+":auth");
         return true;
     }


### PR DESCRIPTION
 - /auth/signUp 후 redis 에서 삭제되던 인증코드를 /auth/verify 후 삭제로 변경
 - 인증코드 유효 이슈 해결

## 👀 이슈

resolve #197 

## 📌 개요

 이전에 발급된 인증코드가 유효한 이슈에 대한 해결

## 👩‍💻 작업 사항

/auth/signUp 후 redis 에서 삭제되던 인증코드를 /auth/verify 후 삭제로 변경


## ✅ 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
