### PR TITLE
fix : 이메일 전송 비동기 처리를 통한 응답 속도 개선

### DIFF
--- a/src/main/java/com/sammaru5/sammaru/config/AsyncConfig.java
+++ b/src/main/java/com/sammaru5/sammaru/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.sammaru5.sammaru.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("Async MailExecuter");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/sammaru5/sammaru/config/AsyncConfig.java
+++ b/src/main/java/com/sammaru5/sammaru/config/AsyncConfig.java
@@ -16,7 +16,7 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setCorePoolSize(2);
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(10);
-        executor.setThreadNamePrefix("Async MailExecuter");
+        executor.setThreadNamePrefix("Async Executer");
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
+++ b/src/main/java/com/sammaru5/sammaru/service/user/UserEmailVerifyService.java
@@ -8,6 +8,7 @@ import com.sammaru5.sammaru.util.CacheKey;
 import com.sammaru5.sammaru.util.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import javax.mail.Message;
 import javax.mail.internet.MimeMessage;
@@ -22,6 +23,7 @@ public class UserEmailVerifyService {
     private final RedisUtil redisUtil;
     private final UserRepository userRepository;
 
+    @Async
     public Boolean sendVerificationCode(String userEmail) {
 
         if( isNotProperEmail(userEmail)){


### PR DESCRIPTION

## 👀 이슈

resolve #199 

## 📌 개요

인증번호 요청후 긴 응답시간의 개선을 위한 작업입니다.

## 👩‍💻 작업 사항

* @Async annontation 사용을 위한 AsyncConifg 클래스 추가
*  UserEmailVerifyService.sendVerificationCode @Async annotation 추가, 다른 thread로 실행

## ✅ 참고 사항
 비동기 처리 전
 <img width="214" alt="Screenshot 2023-05-15 at 9 05 16 PM" src="https://github.com/SAMMaru5/SAMMaruServer/assets/77261327/9b9f9bd6-5b41-4042-8d1f-40bf78081c86">

비동기 처리 후
<img width="210" alt="Screenshot 2023-05-15 at 9 18 10 PM" src="https://github.com/SAMMaru5/SAMMaruServer/assets/77261327/c74ea229-87de-4db0-8201-783584b44097">
